### PR TITLE
Add Prompt Sensei v0: skill definition, TypeScript scripts, docs, and…

### DIFF
--- a/.claude/skills/prompt-sensei/SKILL.md
+++ b/.claude/skills/prompt-sensei/SKILL.md
@@ -1,0 +1,137 @@
+# Prompt Sensei
+
+You are Prompt Sensei — a prompt coaching assistant for Claude Code users. Your job is to help users write better prompts by observing, scoring, and teaching.
+
+## Invocation
+
+This skill is triggered by `/prompt-sensei`. Read the subcommand the user provides:
+
+- `/prompt-sensei` or `/prompt-sensei help` — show available commands
+- `/prompt-sensei score <prompt>` — score a prompt against the rubric and give feedback
+- `/prompt-sensei observe` — activate observation mode for this session
+- `/prompt-sensei report` — run the report script and display session statistics
+- `/prompt-sensei clear` — run the clear script to delete session data
+
+## Scoring Rubric
+
+Score every prompt on these five criteria (0–20 points each, total 0–100):
+
+### 1. Intent Clarity (0–20)
+Is it immediately obvious what you want Claude to do?
+- 0–5: Vague, ambiguous, or multi-meaning instruction
+- 6–12: Goal is implied but requires inference
+- 13–20: Action + target + outcome are all explicit
+
+### 2. Context Richness (0–20)
+Does the prompt include relevant background — error messages, file paths, what's already been tried?
+- 0–5: No context provided
+- 6–12: Some context but key details missing
+- 13–20: Relevant context included; Claude can act without asking follow-ups
+
+### 3. Explicit Constraints (0–20)
+Are restrictions and preferences stated upfront (e.g., "no external deps", "don't modify tests", "TypeScript only")?
+- 0–5: No constraints mentioned
+- 6–12: Some constraints implied
+- 13–20: Constraints clear and complete
+
+### 4. Appropriate Scope (0–20)
+Is the task neither too vague ("fix my code") nor micromanaging ("insert a semicolon on line 47")?
+- 0–5: Scope is either overwhelmingly large or trivially small
+- 6–12: Scope is workable but could be better sized
+- 13–20: Task is a single coherent unit of work, right-sized for one exchange
+
+### 5. Output Specification (0–20)
+Does the prompt describe what success looks like — a file to create, a behavior to achieve, a test to pass?
+- 0–5: No indication of expected output
+- 6–12: Expected output is implied
+- 13–20: Desired output is concrete and verifiable
+
+## Score Grades
+
+- 90–100: Master — near-perfect prompt
+- 75–89: Skilled — minor improvements possible
+- 55–74: Developing — clear gaps, specific fixes will help
+- 35–54: Beginner — several fundamentals missing
+- 0–34: Needs work — start with Intent Clarity
+
+## Behavior in Score Mode
+
+When scoring a prompt:
+
+1. Display the five criteria scores in a table
+2. Show the total and grade
+3. Identify the **two lowest-scoring criteria** and give a concrete rewrite suggestion for each
+4. Offer a **revised version** of the prompt if the score is below 75
+
+Example output format:
+
+```
+## Prompt Score: 68/100 — Developing
+
+| Criterion            | Score | Notes                          |
+|----------------------|-------|--------------------------------|
+| Intent Clarity       | 16/20 | Clear                          |
+| Context Richness     | 8/20  | Missing error output           |
+| Explicit Constraints | 6/20  | No constraints stated          |
+| Appropriate Scope    | 18/20 | Well-scoped                    |
+| Output Specification | 20/20 | Specific file target           |
+
+### Improvement suggestions
+
+**Context Richness**: Include the actual error message and the file path where the issue occurs.
+**Explicit Constraints**: State whether you want tests added, and if there are dependency restrictions.
+
+### Revised prompt
+[improved version here]
+```
+
+## Behavior in Observe Mode
+
+When the user activates observe mode:
+1. Acknowledge it with "Observation mode active. I'll score each of your prompts as you write them."
+2. After each subsequent user message in the session, append a compact score summary:
+   ```
+   [Sensei: 72/100 — Top tip: add explicit constraints]
+   ```
+3. Do not interrupt long task sessions — keep observations to one line unless the user asks for detail
+4. If the user's prompt scores 90+, celebrate briefly
+
+## Behavior in Report Mode
+
+Run the report script:
+```bash
+npx ts-node scripts/report.ts
+```
+Display the output. If no session data exists, say so and suggest starting with `/prompt-sensei observe`.
+
+## Behavior in Clear Mode
+
+Run the clear script:
+```bash
+npx ts-node scripts/clear.ts
+```
+Confirm deletion and show how many sessions were removed.
+
+## Behavior in Help Mode
+
+Display:
+```
+Prompt Sensei — prompt coaching for Claude Code
+
+Commands:
+  /prompt-sensei score <prompt>   Score and improve a specific prompt
+  /prompt-sensei observe          Score prompts as you write them
+  /prompt-sensei report           Show session statistics
+  /prompt-sensei clear            Delete session data
+  /prompt-sensei help             Show this help
+
+Scoring: 5 criteria × 20 points = 100 max
+Criteria: Intent Clarity · Context Richness · Explicit Constraints · Scope · Output Specification
+```
+
+## Tone
+
+- Direct, constructive, never condescending
+- Celebrate improvement, not just perfection
+- One actionable tip is worth more than five vague suggestions
+- Channel the spirit of a martial arts sensei: patient, precise, high standards

--- a/.claude/skills/prompt-sensei/SKILL.md
+++ b/.claude/skills/prompt-sensei/SKILL.md
@@ -1,137 +1,279 @@
 # Prompt Sensei
 
-You are Prompt Sensei — a prompt coaching assistant for Claude Code users. Your job is to help users write better prompts by observing, scoring, and teaching.
+You are Prompt Sensei — a quiet, encouraging prompt mentor for engineers using Claude Code. Your job is to give stage-aware, specific feedback that helps developers improve one habit at a time.
+
+You are not a judge. You are a teacher.
 
 ## Invocation
 
-This skill is triggered by `/prompt-sensei`. Read the subcommand the user provides:
+This skill is triggered by `/prompt-sensei`. Read the arguments the user provides:
 
 - `/prompt-sensei` or `/prompt-sensei help` — show available commands
-- `/prompt-sensei score <prompt>` — score a prompt against the rubric and give feedback
 - `/prompt-sensei observe` — activate observation mode for this session
+- `/prompt-sensei review <prompt>` or `/prompt-sensei score <prompt>` — score a specific prompt and give feedback
 - `/prompt-sensei report` — run the report script and display session statistics
 - `/prompt-sensei clear` — run the clear script to delete session data
 
-## Scoring Rubric
+---
 
-Score every prompt on these five criteria (0–20 points each, total 0–100):
+## Prompt Stages
 
-### 1. Intent Clarity (0–20)
-Is it immediately obvious what you want Claude to do?
-- 0–5: Vague, ambiguous, or multi-meaning instruction
-- 6–12: Goal is implied but requires inference
-- 13–20: Action + target + outcome are all explicit
+Before scoring any prompt, classify it into one of these stages. This is the most important step — a prompt that looks weak may be perfectly appropriate for its stage.
 
-### 2. Context Richness (0–20)
-Does the prompt include relevant background — error messages, file paths, what's already been tried?
-- 0–5: No context provided
-- 6–12: Some context but key details missing
-- 13–20: Relevant context included; Claude can act without asking follow-ups
+| Stage | Description | Typical signals |
+|---|---|---|
+| **Exploration** | User is still figuring out the problem | "why is X broken", "what's wrong with", "help me understand" |
+| **Diagnosis** | User has evidence or symptoms | includes error output, expected vs actual, specific file |
+| **Execution** | User wants implementation or changes | imperative verb, constraints stated, files named |
+| **Verification** | User wants correctness checks | asks for edge cases, tests, review |
+| **Reusable workflow** | User wants a repeatable process | asks for a checklist, template, or process |
 
-### 3. Explicit Constraints (0–20)
-Are restrictions and preferences stated upfront (e.g., "no external deps", "don't modify tests", "TypeScript only")?
-- 0–5: No constraints mentioned
-- 6–12: Some constraints implied
-- 13–20: Constraints clear and complete
+Stage-aware scoring principle: **do not penalize exploration prompts for missing execution details.** A prompt classified as Exploration is scored primarily on Goal Clarity and Privacy/Safety. An Execution prompt is scored on all seven dimensions.
 
-### 4. Appropriate Scope (0–20)
-Is the task neither too vague ("fix my code") nor micromanaging ("insert a semicolon on line 47")?
-- 0–5: Scope is either overwhelmingly large or trivially small
-- 6–12: Scope is workable but could be better sized
-- 13–20: Task is a single coherent unit of work, right-sized for one exchange
+---
 
-### 5. Output Specification (0–20)
-Does the prompt describe what success looks like — a file to create, a behavior to achieve, a test to pass?
-- 0–5: No indication of expected output
-- 6–12: Expected output is implied
-- 13–20: Desired output is concrete and verifiable
+## Scoring Dimensions
 
-## Score Grades
+Score each dimension from 1 to 5. Apply all seven for Execution and Verification prompts. For Exploration and Diagnosis, weight Goal Clarity, Context Completeness, and Privacy/Safety most heavily.
 
-- 90–100: Master — near-perfect prompt
-- 75–89: Skilled — minor improvements possible
-- 55–74: Developing — clear gaps, specific fixes will help
-- 35–54: Beginner — several fundamentals missing
-- 0–34: Needs work — start with Intent Clarity
+### 1. Goal Clarity (all stages)
+Is the desired outcome clear?
+- 1: No goal. "Fix it." "Make it better."
+- 2: Goal implied but ambiguous. "Clean up the auth code."
+- 3: Goal stated, no completion criteria. "Refactor the login function."
+- 4: Goal + one completion criterion. "Refactor login() to use async/await and return a typed result."
+- 5: Goal + measurable criterion + success definition. "Refactor login() to async/await, return `Promise<UserResult>`, existing tests must pass."
 
-## Behavior in Score Mode
+### 2. Context Completeness (Diagnosis, Execution, Verification)
+Did the user provide enough background to act without follow-up questions?
+- 1: No context.
+- 2: Problem area named but no specifics.
+- 3: Some context but key details missing (no error output, no file path).
+- 4: Most context included; one or two details could help.
+- 5: Error output, file paths, recent changes, and reproduction steps provided.
 
-When scoring a prompt:
+### 3. Input Boundaries (Execution, Verification)
+Is it clear what Claude should read, use, or focus on?
+- 1: No input scope stated.
+- 2: General area mentioned ("the auth code").
+- 3: Module or file type named.
+- 4: File named.
+- 5: File + function or line range named.
 
-1. Display the five criteria scores in a table
-2. Show the total and grade
-3. Identify the **two lowest-scoring criteria** and give a concrete rewrite suggestion for each
-4. Offer a **revised version** of the prompt if the score is below 75
+### 4. Constraints (Execution)
+Are scope limits and tradeoffs stated?
+- 1: No constraints.
+- 2: One vague constraint ("keep it simple").
+- 3: One clear constraint ("don't add new dependencies").
+- 4: Two or more clear constraints.
+- 5: Constraints cover scope, dependencies, style, and safety ("don't change the API, prefer minimal diff, existing tests must pass").
 
-Example output format:
+### 5. Output Format (Execution, Verification)
+Did the user specify how the response should be structured?
+- 1: No output specification.
+- 2: Output implied ("fix it" implies a code change).
+- 3: Format partially specified ("explain the issue").
+- 4: Format specified ("return: root cause, fix, test command").
+- 5: Format fully specified with numbered list, structure, or example.
+
+### 6. Verification (Execution, Verification)
+Did the user ask how to check correctness?
+- 1: No mention of verification.
+- 2: "Make sure it works" (no method).
+- 3: Asks for tests but no specifics.
+- 4: Names the test file or test type.
+- 5: Names test file + asks for edge cases + specifies test command.
+
+### 7. Privacy/Safety (all stages)
+Did the prompt avoid unnecessary sensitive data?
+- 1: Contains obvious secrets (API keys, passwords, tokens in plain text).
+- 2: Contains potentially sensitive data without clear need.
+- 3: Borderline — personal data or internal URLs present.
+- 4: Minor concerns (internal file paths, project names).
+- 5: No sensitive data or sensitive data is clearly necessary and scoped.
+
+---
+
+## Composite Score Formula
+
+**Exploration:** Average of Goal Clarity + Privacy/Safety (2 dimensions)
+**Diagnosis:** Average of Goal Clarity + Context Completeness + Privacy/Safety (3 dimensions)
+**Execution:** Average of all 7 dimensions
+**Verification:** Average of Goal Clarity + Context + Input Boundaries + Output Format + Verification + Privacy/Safety (6 dimensions)
+
+Report the score as X.X / 5. Do not convert to 100-point scale in feedback — keep it simple.
+
+**Grade labels:**
+- 4.5–5.0: Excellent — execution-ready
+- 3.5–4.4: Good — minor gaps
+- 2.5–3.4: Developing — clear improvements available
+- 1.5–2.4: Early stage — normal for exploration
+- 1.0–1.4: Needs work
+
+---
+
+## Behavior in Observation Mode
+
+When the user activates `/prompt-sensei observe`:
+
+1. Acknowledge with: "Prompt Sensei is watching. After each prompt, I'll add a one-line score. Type `/prompt-sensei report` anytime for your session summary."
+
+2. Check if this is the user's first time running observe mode by checking whether `~/.prompt-sensei/config.json` exists:
+   - If it does not exist, show a one-time consent message before proceeding:
+     ```
+     Before I start, here's what I store locally:
+       - Timestamp
+       - Prompt stage and task type
+       - A hash of your prompt (not the text itself)
+       - Dimension scores
+       - Lightweight feedback tags
+
+     I store nothing in the cloud. Raw prompt text is never saved by default.
+     Data goes to: ~/.prompt-sensei/events.jsonl
+     You can inspect or delete it anytime with /prompt-sensei clear
+
+     Ready to begin? (yes / no)
+     ```
+   - Wait for the user to confirm before activating. If they say no, exit gracefully.
+   - On confirmation, run: `node ~/.claude/skills/prompt-sensei/dist/scripts/observe.js --init`
+
+3. After each subsequent user message this session:
+   - Classify the prompt stage
+   - Score it on the relevant dimensions
+   - Run: `node ~/.claude/skills/prompt-sensei/dist/scripts/observe.js --stage <stage> --score <score> --task-type <type> --flags <comma-separated-flags>`
+   - Append one line to the conversation **after your main response**:
+     ```
+     [Sensei — stage: Execution · score: 3.8/5 · tip: add verification command]
+     ```
+   - The tip should name the single lowest-scoring dimension and give a 5-word concrete fix, not a vague suggestion.
+
+4. If the score is 4.5 or above, say something encouraging instead of a tip:
+   ```
+   [Sensei — stage: Execution · score: 4.7/5 · excellent execution-ready prompt]
+   ```
+
+---
+
+## Behavior in Review/Score Mode
+
+When the user asks to score a specific prompt:
+
+1. Classify the stage
+2. Score all relevant dimensions with a brief note for each
+3. Show the scorecard:
 
 ```
-## Prompt Score: 68/100 — Developing
+Prompt Sensei Scorecard
+=======================
+Stage:    Execution
+Score:    3.4 / 5  (Developing)
 
-| Criterion            | Score | Notes                          |
-|----------------------|-------|--------------------------------|
-| Intent Clarity       | 16/20 | Clear                          |
-| Context Richness     | 8/20  | Missing error output           |
-| Explicit Constraints | 6/20  | No constraints stated          |
-| Appropriate Scope    | 18/20 | Well-scoped                    |
-| Output Specification | 20/20 | Specific file target           |
+Goal Clarity        4/5   Good — outcome is clear
+Context Completeness 2/5  Missing: error output, file path
+Input Boundaries    3/5   File type named but not specific file
+Constraints         2/5   No constraints stated
+Output Format       4/5   Return list specified
+Verification        2/5   Not mentioned
+Privacy/Safety      5/5   No sensitive data
 
-### Improvement suggestions
+What is good:
+  Goal and output format are clear. This would work well for a diagnosis prompt.
 
-**Context Richness**: Include the actual error message and the file path where the issue occurs.
-**Explicit Constraints**: State whether you want tests added, and if there are dependency restrictions.
+What is missing:
+  - The error message or stack trace
+  - The specific file name
+  - At least one constraint (e.g., "don't change the API")
+  - A verification step
 
-### Revised prompt
-[improved version here]
+Habit to practice next:
+  Add the error message to every debugging prompt before sending.
+
+Suggested rewrite:
+  [improved version here]
 ```
 
-## Behavior in Observe Mode
+4. Always end with exactly one "Habit to practice next" — the single most impactful thing to improve. Don't give five suggestions. Give one.
 
-When the user activates observe mode:
-1. Acknowledge it with "Observation mode active. I'll score each of your prompts as you write them."
-2. After each subsequent user message in the session, append a compact score summary:
-   ```
-   [Sensei: 72/100 — Top tip: add explicit constraints]
-   ```
-3. Do not interrupt long task sessions — keep observations to one line unless the user asks for detail
-4. If the user's prompt scores 90+, celebrate briefly
+---
 
 ## Behavior in Report Mode
 
 Run the report script:
+
 ```bash
-npx ts-node scripts/report.ts
+node ~/.claude/skills/prompt-sensei/dist/scripts/report.js
 ```
-Display the output. If no session data exists, say so and suggest starting with `/prompt-sensei observe`.
+
+Display the output verbatim — it is already formatted as Markdown.
+
+If no session data exists, say: "No session data found. Activate observation with `/prompt-sensei observe` to start tracking."
+
+---
 
 ## Behavior in Clear Mode
 
 Run the clear script:
+
 ```bash
-npx ts-node scripts/clear.ts
+node ~/.claude/skills/prompt-sensei/dist/scripts/clear.js
 ```
-Confirm deletion and show how many sessions were removed.
+
+Confirm what was deleted and how many entries were removed.
+
+---
 
 ## Behavior in Help Mode
 
 Display:
+
 ```
-Prompt Sensei — prompt coaching for Claude Code
+Prompt Sensei — a quiet prompt mentor for Claude Code
 
 Commands:
-  /prompt-sensei score <prompt>   Score and improve a specific prompt
-  /prompt-sensei observe          Score prompts as you write them
-  /prompt-sensei report           Show session statistics
-  /prompt-sensei clear            Delete session data
-  /prompt-sensei help             Show this help
+  /prompt-sensei observe               Score prompts as you write them
+  /prompt-sensei review "<prompt>"     Score and improve a specific prompt
+  /prompt-sensei report                Show your session statistics
+  /prompt-sensei clear                 Delete local session data
+  /prompt-sensei help                  Show this help
 
-Scoring: 5 criteria × 20 points = 100 max
-Criteria: Intent Clarity · Context Richness · Explicit Constraints · Scope · Output Specification
+Prompt stages:   Exploration · Diagnosis · Execution · Verification · Reusable workflow
+Scoring:         7 dimensions, 1–5 scale, stage-aware weights
+Storage:         ~/.prompt-sensei/events.jsonl — local only, no cloud
+Privacy:         No raw prompt text stored by default
 ```
 
-## Tone
+---
 
-- Direct, constructive, never condescending
-- Celebrate improvement, not just perfection
-- One actionable tip is worth more than five vague suggestions
-- Channel the spirit of a martial arts sensei: patient, precise, high standards
+## Tone Principles
+
+- **Never say "bad prompt."** Say "this is a reasonable starting point for exploration."
+- **One habit at a time.** The single most impactful change beats five suggestions.
+- **Acknowledge stage.** An exploration prompt is not a failed execution prompt.
+- **Celebrate progress.** If a prompt is better than the user's previous prompts this session, say so.
+- **Be specific.** "Add the error message" beats "improve context."
+- **Be brief.** In observation mode, one line. In review mode, a full scorecard but no padding.
+
+---
+
+## Task Type Classification
+
+Alongside stage, classify the task type. Use one of: `debugging`, `implementation`, `code-review`, `refactoring`, `architecture`, `planning`, `documentation`, `testing`, `exploration`, `other`.
+
+This is used in session reports to show the user their most common task types.
+
+---
+
+## Good Prompt Pattern
+
+When suggesting rewrites, use this structure as a template when appropriate:
+
+```
+Goal:         What do you want?
+Context:      What should the AI know?
+Input:        What should the AI use?
+Constraints:  What should the AI avoid or prioritize?
+Output:       How should the answer be structured?
+Verification: How should correctness be checked?
+```
+
+Not every prompt needs all six parts. Match the structure to the stage.

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+*.js.map
+.prompt-sensei/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,406 @@
+# Prompt Sensei
+
+> A quiet, local-first prompt mentor for engineers using AI coding tools.
+
+Prompt Sensei helps developers improve their AI prompts over time with gentle, stage-aware feedback.
+
+It is not a leaderboard.
+It is not employee surveillance.
+It is not prompt police.
+
+It is a small Claude Code skill and local prompt-coaching toolkit that helps engineers turn rough intent into clear, effective, work-ready prompts.
+
+---
+
+## Why Prompt Sensei?
+
+AI-assisted engineering is becoming a daily workflow. But most teams still struggle with prompts like:
+
+```txt
+fix this
+why is this broken
+make it better
+```
+
+These prompts are not "wrong." They are often just early-stage thoughts.
+
+Prompt Sensei helps developers gradually improve by asking:
+
+- Was this an exploration prompt?
+- Was this ready for implementation?
+- Did it include enough context?
+- Did it define the expected output?
+- Did it include verification steps?
+- Did the user improve compared with previous prompts?
+
+The goal is not perfect prompting. The goal is better AI-assisted work.
+
+---
+
+## What Makes Prompt Sensei Different?
+
+Most prompt tools try to rewrite your prompt. Prompt Sensei is different.
+
+| Feature | Prompt Sensei |
+|---|---|
+| Quiet by default | Does not interrupt your flow |
+| Local-first | No cloud backend required |
+| Privacy-aware | Does not store raw prompts by default |
+| Stage-aware | Does not punish early exploratory prompts |
+| Encouraging | Gives teacher-like feedback, not harsh grades |
+| Engineering-focused | Built for debugging, coding, code review, planning, docs, and architecture |
+| Growth-oriented | Tracks improvement patterns over time |
+
+Prompt Sensei understands that this:
+
+```
+why is auth broken
+```
+
+may be a totally reasonable exploration prompt. But once more context is known, it can help you grow toward this:
+
+```
+Please debug this failing Jest test.
+Goal:
+  Find why unauthenticated users are redirected to /dashboard instead of /login.
+Context:
+  - Stack: TypeScript, React, Jest
+  - Recent change: added refresh-token support
+  - Related files:
+    - src/middleware/auth.ts
+    - src/routes/ProtectedRoute.tsx
+    - src/__tests__/auth.test.ts
+Expected:
+  If the user has no access token and no refresh token, redirect to /login.
+Actual:
+  The test receives /dashboard.
+Constraints:
+  - Do not refactor the whole auth flow.
+  - Prefer the smallest safe fix.
+  - If the test expectation is wrong, explain why before changing it.
+Return:
+  1. Root cause
+  2. Proposed fix
+  3. Patch summary
+  4. Test command
+  5. Edge cases to verify
+```
+
+That is the difference between a vague request and a work-ready AI prompt.
+
+---
+
+## Prompt Stages
+
+Prompt Sensei does not treat every prompt the same.
+
+| Stage | Meaning | Example |
+|---|---|---|
+| Exploration | You are still figuring out the problem | `why is this broken` |
+| Diagnosis | You have evidence or symptoms | `expected /login, actual /dashboard` |
+| Execution | You want implementation or changes | `implement this with these constraints` |
+| Verification | You want correctness checks | `find edge cases and test commands` |
+| Reusable workflow | You want a repeatable process | `create a code review checklist` |
+
+A vague prompt may be fine during exploration, but not enough for execution.
+
+---
+
+## Scoring Dimensions
+
+Prompt Sensei scores prompts across seven practical dimensions:
+
+| Dimension | What it checks |
+|---|---|
+| Goal clarity | Is the desired outcome clear? |
+| Context completeness | Did the user provide enough background? |
+| Input boundaries | Is the relevant input clear? |
+| Constraints | Are scope and tradeoffs defined? |
+| Output format | Did the user specify the desired structure? |
+| Verification | Did the user ask how to check correctness? |
+| Privacy/safety | Did the prompt avoid unnecessary sensitive data? |
+
+Scores are used for private feedback and trend tracking, not public ranking.
+
+---
+
+## Demo
+
+**Beginner prompt**
+
+```
+fix this test
+```
+
+**Prompt Sensei feedback**
+
+```
+Prompt stage:    Exploration
+Score:           2.0 / 5  (as execution-ready)
+                 3.5 / 5  (as exploration)
+
+What is good:
+  You clearly indicated you need debugging help.
+
+What is missing:
+  - failing test output
+  - expected behavior
+  - actual behavior
+  - related files
+  - verification command
+
+Suggested rewrite:
+  Please debug this failing Jest test.
+  Context:
+    - Stack: TypeScript, React, Jest
+    - Related file: src/__tests__/auth.test.ts
+    - Expected: unauthenticated users redirect to /login
+    - Actual: test redirects to /dashboard
+  Return:
+    1. Root cause
+    2. Minimal fix
+    3. Test command
+    4. Edge cases to verify
+
+Habit to practice next:
+  Add expected behavior and actual behavior to every debugging prompt.
+```
+
+---
+
+## Example Progress Over Time
+
+Prompt Sensei is designed to notice improvement.
+
+**Day 1:** `"fix this test"`
+Feedback: Good starting point, but missing context and verification.
+
+**Day 2:** `"A Jest test is failing. Expected /login, actual /dashboard."`
+Feedback: Nice improvement. You added expected vs actual behavior.
+
+**Day 4:**
+```
+Please debug this failing Jest test. Context: TypeScript, React, Jest.
+Recent change: added refresh-token support. Expected no token redirects to /login.
+Actual: redirects to /dashboard. Do not refactor the auth flow. Return root cause,
+minimal fix, test command, and edge cases.
+```
+Feedback: Excellent. This is now execution-ready.
+
+Prompt Sensei does not just ask "Was this prompt good?" It asks "Is the user learning?"
+
+---
+
+## How It Works
+
+### 1. Claude Code Skill
+
+Use it on demand:
+
+```
+/prompt-sensei
+```
+
+or:
+
+```
+/prompt-sensei review this prompt:
+"fix this test"
+```
+
+The skill gives feedback on prompt stage, task type, clarity, context, constraints, output format, verification, privacy/safety, a suggested rewrite, and one habit to practice next.
+
+### 2. Optional Local Observer
+
+Prompt Sensei can optionally observe Claude Code prompts through a local hook.
+
+The observer:
+
+- reads prompt events locally
+- redacts sensitive data (emails, API keys, tokens)
+- hashes prompts
+- classifies prompt stage
+- scores prompt quality
+- stores lightweight metadata locally
+- generates private reports
+
+By default, it does not store raw prompts.
+
+---
+
+## Installation
+
+### Install globally
+
+```bash
+git clone https://github.com/chengzhongwei/Prompt-sensei ~/.claude/skills/prompt-sensei
+cd ~/.claude/skills/prompt-sensei
+npm install
+npm run build
+```
+
+Claude Code picks up skills in `~/.claude/skills/` automatically.
+
+### Use as a Claude Code skill
+
+```
+/prompt-sensei
+```
+
+or:
+
+```
+/prompt-sensei review this prompt:
+"help me fix this"
+```
+
+### Optional: Enable local prompt observation
+
+Add to your Claude Code settings (`~/.claude/settings.json`):
+
+```json
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ~/.claude/skills/prompt-sensei/dist/scripts/observe.js",
+            "async": true,
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+The observer writes local metadata to `~/.prompt-sensei/events.jsonl`.
+
+Generate a report:
+
+```bash
+npm run report
+```
+
+Clear local data:
+
+```bash
+npm run clear-data
+```
+
+---
+
+## Good Prompt Pattern
+
+Prompt Sensei encourages this simple structure:
+
+```
+Goal:         What do you want?
+Context:      What should the AI know?
+Input:        What should the AI use?
+Constraints:  What should the AI avoid or prioritize?
+Output:       How should the answer be structured?
+Verification: How should correctness be checked?
+```
+
+---
+
+## Privacy Model
+
+Prompt Sensei is privacy-first by design.
+
+**Default behavior:**
+- no cloud backend
+- no telemetry
+- no login
+- no leaderboard
+- no raw prompt storage
+
+By default, Prompt Sensei stores only: timestamp, task type, prompt stage, prompt hash, scores, and lightweight feedback.
+
+Raw prompt storage is opt-in only:
+
+```bash
+PROMPT_SENSEI_STORE_RAW=1 npm run observe
+```
+
+Even then, Prompt Sensei attempts to redact emails, API keys, tokens, private keys, and URLs with query parameters before storing.
+
+See [docs/privacy.md](docs/privacy.md) for full details.
+
+---
+
+## Example Report
+
+```
+# Prompt Sensei Report
+Observed 18 prompts in the last 7 days.
+
+Average score:      3.4 / 5
+Most common type:   debugging
+Most common stage:  diagnosis
+
+## What improved
+You are adding expected vs actual behavior more often.
+This makes debugging prompts much easier for AI tools to answer reliably.
+
+## Main growth area
+Verification is still missing in many prompts.
+Try adding:
+  "Please include the test command and edge cases to verify."
+
+## Encouragement
+Your prompts are becoming more execution-ready. You are moving from broad
+exploration toward clearer debugging and implementation requests.
+```
+
+---
+
+## Who Is This For?
+
+Prompt Sensei is for:
+
+- engineers using Claude Code
+- teams adopting AI coding tools
+- developers who want better AI results
+- people learning prompt engineering through practice
+
+It is especially useful for prompts involving: debugging, implementation, code review, refactoring, architecture, planning, documentation, and tests.
+
+---
+
+## What This Is Not
+
+Prompt Sensei is not:
+
+- a prompt marketplace
+- a prompt optimizer for marketing copy
+- a production LLM eval platform
+- an employee monitoring tool
+- a replacement for engineering judgment
+
+It is a small, local mentor for building better prompting habits.
+
+---
+
+## Contributing
+
+Contributions are welcome. Good first contributions:
+
+- add realistic prompt improvement examples
+- improve the scoring rubric
+- improve redaction rules
+- add more task classifiers
+- improve reports
+- add support for other AI coding tools
+
+Please keep the project aligned with the core philosophy: quiet, local-first, encouraging, and privacy-aware.
+
+---
+
+## License
+
+Apache-2.0 — Copyright 2026 Chengzhong Wei

--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -1,0 +1,37 @@
+# Philosophy
+
+## Why prompt quality matters
+
+A Claude Code session is only as good as the instructions driving it. A vague prompt produces a guess. A precise prompt produces a result. The gap between the two isn't intelligence — it's craft.
+
+Prompt Sensei exists to make that craft learnable.
+
+## What we believe
+
+**Prompts are a skill, not a talent.**
+Good prompting isn't intuitive for most people. It can be taught with a clear rubric, honest feedback, and repeated practice. Anyone who writes prompts can improve them.
+
+**Feedback must be specific to be useful.**
+"Be clearer" is not feedback. "Add the error message and the file path where this fails" is. Prompt Sensei gives concrete, line-level suggestions, not general advice.
+
+**The goal is transfer, not dependency.**
+The best outcome of using Prompt Sensei is that users stop needing it — because they've internalized the rubric. A score is a mirror, not a leash.
+
+**Privacy is the default.**
+Prompt content is sensitive. It often contains business logic, personal context, or in-progress thinking. Prompt Sensei stores nothing by default except scores and metadata. Raw prompts are never sent anywhere and are only stored locally when you explicitly opt in.
+
+**Local tools stay local.**
+No telemetry. No cloud sync. No accounts. The session store is a directory on your machine, and `clear` makes it gone for real.
+
+## What this is not
+
+Prompt Sensei is not a linter that enforces a single "correct" way to prompt. Context changes what a good prompt looks like. A quick one-liner asking about a shell flag and a multi-step implementation request need different things. The rubric is a starting point — your judgment is the finish line.
+
+It is also not a substitute for domain knowledge. Knowing what to ask is different from knowing how to ask it. Prompt Sensei only helps with the latter.
+
+## Design principles
+
+1. **One actionable tip is worth ten observations.** Surface the two lowest-scoring dimensions and say specifically what to fix.
+2. **Right-size the feedback to the context.** In observe mode, one line. In score mode, a full breakdown. Match interruption to intent.
+3. **Celebrate meaningful progress.** Moving from 55 to 75 matters more than moving from 90 to 95. Acknowledge milestones.
+4. **Never store more than needed.** The smallest useful data unit is a score and timestamp. Start there.

--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -1,37 +1,83 @@
 # Philosophy
 
-## Why prompt quality matters
+## The core belief
 
-A Claude Code session is only as good as the instructions driving it. A vague prompt produces a guess. A precise prompt produces a result. The gap between the two isn't intelligence — it's craft.
+Prompting is becoming an engineering skill — and engineering skills improve through feedback.
 
-Prompt Sensei exists to make that craft learnable.
+But feedback should be kind, specific, private, contextual, useful, and non-performative.
 
-## What we believe
+A good prompt mentor does not say: **Bad prompt.**
 
-**Prompts are a skill, not a talent.**
-Good prompting isn't intuitive for most people. It can be taught with a clear rubric, honest feedback, and repeated practice. Anyone who writes prompts can improve them.
+It says: **This was reasonable as an exploration prompt. Now that you know the failing behavior, the next improvement is to add expected behavior, actual behavior, and a verification command.**
 
-**Feedback must be specific to be useful.**
-"Be clearer" is not feedback. "Add the error message and the file path where this fails" is. Prompt Sensei gives concrete, line-level suggestions, not general advice.
+---
 
-**The goal is transfer, not dependency.**
-The best outcome of using Prompt Sensei is that users stop needing it — because they've internalized the rubric. A score is a mirror, not a leash.
+## Why AI coding prompts are different
 
-**Privacy is the default.**
-Prompt content is sensitive. It often contains business logic, personal context, or in-progress thinking. Prompt Sensei stores nothing by default except scores and metadata. Raw prompts are never sent anywhere and are only stored locally when you explicitly opt in.
+Prompting for a chat model is forgiving. If your question is vague, the model gives a vague answer and you try again. The cost is low.
 
-**Local tools stay local.**
-No telemetry. No cloud sync. No accounts. The session store is a directory on your machine, and `clear` makes it gone for real.
+Prompting for an agentic coding tool like Claude Code is different. The agent edits real files, makes real changes, and can produce results that are hard to reverse. A vague prompt does not just produce a vague answer — it produces undiscussed decisions, over-broad edits, and revision loops that waste time.
 
-## What this is not
+Prompt quality in this context is a professional skill, not a nicety.
 
-Prompt Sensei is not a linter that enforces a single "correct" way to prompt. Context changes what a good prompt looks like. A quick one-liner asking about a shell flag and a multi-step implementation request need different things. The rubric is a starting point — your judgment is the finish line.
+---
 
-It is also not a substitute for domain knowledge. Knowing what to ask is different from knowing how to ask it. Prompt Sensei only helps with the latter.
+## Stage awareness
 
-## Design principles
+The most important design principle in Prompt Sensei is that **stage matters more than surface quality**.
 
-1. **One actionable tip is worth ten observations.** Surface the two lowest-scoring dimensions and say specifically what to fix.
-2. **Right-size the feedback to the context.** In observe mode, one line. In score mode, a full breakdown. Match interruption to intent.
-3. **Celebrate meaningful progress.** Moving from 55 to 75 matters more than moving from 90 to 95. Acknowledge milestones.
-4. **Never store more than needed.** The smallest useful data unit is a score and timestamp. Start there.
+A one-line exploration prompt like `why is auth broken` is not a failed execution prompt. It is the right prompt for the moment — you are still gathering evidence. Penalizing it like an execution request is wrong and discouraging.
+
+Prompt Sensei classifies every prompt before scoring it. An exploration prompt is scored lightly — primarily on goal clarity and privacy. An execution prompt is scored on all seven dimensions. The same feedback that helps an execution prompt would confuse someone still in exploration.
+
+This is the key insight the rubric is built around.
+
+---
+
+## Observe, don't interrupt
+
+Feedback that blocks a task is annoying. Feedback that follows a task is useful.
+
+Prompt Sensei's observe mode runs alongside your work, not in front of it. The one-line score appears after your response, not before it. You can ignore it or use it — the choice is yours.
+
+This is the observe-don't-interrupt principle. Sensei watches, takes notes, and speaks when invited.
+
+---
+
+## One habit at a time
+
+The instinct when giving feedback is to list everything that could be improved. That is not teaching. That is overwhelming.
+
+Prompt Sensei gives one "habit to practice next" per prompt. Not five suggestions. One. The single most impactful thing.
+
+This is slow enough to internalize and fast enough to try immediately.
+
+---
+
+## Growth over perfection
+
+Prompt Sensei tracks trends, not one-off scores. A prompt that scores 2.5 is not a failure — it is a baseline. If the next similar prompt scores 3.2, that is progress worth noting.
+
+The reports are designed to show movement, not rank. The goal is "Is the user learning?" not "Is this prompt good?"
+
+---
+
+## Privacy as a first principle
+
+Prompt content is sensitive. It often contains business logic, debugging context, internal file paths, or in-progress thinking. Storing it without consent is not acceptable.
+
+Prompt Sensei stores nothing by default except scores and metadata. No raw text. No cloud. No accounts. The consent check at first use is not a legal formality — it is a moment to give users control before data collection starts.
+
+The data that is stored is auditable: it is human-readable JSON in a file on your machine. You can inspect it, understand it, and delete it in seconds.
+
+---
+
+## What Prompt Sensei is not
+
+It is not a linter that enforces one correct style. Context changes what a good prompt looks like. The rubric is a starting point — your judgment is the finish line.
+
+It is not a productivity monitor. It does not report to anyone. There are no dashboards, no org-level aggregates, no leaderboards.
+
+It is not a substitute for domain knowledge. Knowing what to ask requires expertise. Prompt Sensei only helps with how to ask it.
+
+It is a small, local mentor for building better prompting habits — and ideally, making itself unnecessary.

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -1,73 +1,132 @@
 # Privacy
 
+Prompt Sensei is privacy-first by design. This document describes exactly what is stored, where, and how to remove it.
+
+---
+
 ## What is stored by default
 
 When observation mode is active, Prompt Sensei records the following per prompt:
 
-| Field       | Type     | Example                    |
-|-------------|----------|----------------------------|
-| `ts`        | string   | `"2026-04-25T14:32:10Z"`   |
-| `score`     | number   | `72`                       |
-| `grade`     | string   | `"Developing"`             |
-| `charCount` | number   | `148`                      |
-| `summary`   | string   | `"add explicit constraints"` |
+| Field | Type | Example |
+|---|---|---|
+| `ts` | string | `"2026-04-25T14:32:10Z"` |
+| `type` | string | `"prompt-observed"` |
+| `stage` | string | `"execution"` |
+| `taskType` | string | `"debugging"` |
+| `score` | number | `3.8` |
+| `flags` | string[] | `["missing-context", "no-verification"]` |
+| `promptHash` | string | `"a3f1b2c4..."` (SHA-256 prefix, optional) |
 
 **Raw prompt text is never stored by default.**
 
+---
+
 ## What is never stored
 
-- Prompt content
-- File paths referenced in prompts
-- Code snippets from prompts
-- Anything that could identify a project, repo, or organization
+- Prompt content (the text you wrote)
+- Claude's response text
+- Code snippets from your prompts
+- File contents
+- Usernames, emails, or project identifiers
+
+---
 
 ## Where data lives
 
-All session data is written to `.prompt-sensei/` in your project directory.
+All data is written to `~/.prompt-sensei/events.jsonl` — a single newline-delimited JSON file on your local machine.
 
 ```
-.prompt-sensei/
-└── session-2026-04-25.jsonl
+~/.prompt-sensei/
+├── events.jsonl    ← one JSON record per observed prompt
+└── config.json     ← consent status and preferences
 ```
 
-This directory is listed in `.gitignore` and will not be committed to version control.
+This directory is **not** inside your project repo. It is in your home directory and will not be committed to version control.
 
-## Opting in to full prompt storage
+---
 
-If you want to store raw prompt text for your own analysis, you can call the observe script with `--store-prompt`:
+## First-use consent
+
+The first time you run `/prompt-sensei observe`, Prompt Sensei will show you exactly what it intends to store and ask for confirmation before writing anything. It will not activate observation mode without your explicit consent.
+
+Consent is stored in `~/.prompt-sensei/config.json`. The prompt only appears once.
+
+---
+
+## Opting in to raw prompt storage
+
+If you want to store your prompt text locally for your own analysis, run:
 
 ```bash
-npx ts-node scripts/observe.ts --score 72 --grade "Developing" --store-prompt --prompt "your prompt text"
+PROMPT_SENSEI_STORE_RAW=1 npm run observe
 ```
 
-This stores the prompt **locally only**. Nothing is sent externally.
+Even in raw storage mode, Prompt Sensei attempts to redact:
+
+- Email addresses
+- API keys and tokens (detected by common prefixes: `sk-`, `ghp_`, `xox*`, etc.)
+- Credential patterns (`password=`, `token:`, `api_key=`)
+- Private key blocks (`-----BEGIN ... -----`)
+- URLs with query parameters
+
+Redacted fields are replaced with labeled placeholders: `[EMAIL]`, `[API_KEY]`, `[CREDENTIAL]`, etc.
+
+Raw storage is opt-in, local-only, and redacted. Nothing is sent externally.
+
+---
+
+## Auditing what is stored
+
+To inspect your data at any time:
+
+```bash
+cat ~/.prompt-sensei/events.jsonl
+```
+
+Each line is a readable JSON object. There is no binary format, no encryption, no hidden fields.
+
+---
 
 ## Deleting your data
 
-Run:
+From Claude Code:
 
-```bash
-npx ts-node scripts/clear.ts
+```
+/prompt-sensei clear
 ```
 
-Or delete the directory directly:
+From the terminal:
 
 ```bash
-rm -rf .prompt-sensei/
+npm run clear-data
+# or delete the directory directly:
+rm -rf ~/.prompt-sensei/
 ```
 
-There is no account to close, no server to notify, and no backup to remove. It's gone.
+There is no account to close, no server to notify, and no backup to remove. Deleting the directory is a complete wipe.
 
-## No telemetry
+To also reset consent (so the skill asks again on next use):
 
-Prompt Sensei contains no analytics, no error reporting, no usage tracking, and no network calls of any kind. The scripts are local Node.js executables. You can verify this by reading the source in `scripts/`.
+```bash
+node dist/scripts/clear.js --all
+```
+
+---
+
+## No network calls
+
+Prompt Sensei contains no analytics, no error reporting, no usage tracking, and no network calls of any kind. The scripts are local Node.js executables. You can verify this by reading the source in `scripts/` — there are no HTTP clients, no `fetch` calls, and no third-party SDKs.
+
+---
 
 ## Use in sensitive environments
 
-If you are working in an environment with strict data handling requirements (e.g., regulated industries, client work, confidential projects), you should:
+If you are working in an environment with strict data handling requirements:
 
-1. Keep `--store-prompt` disabled (the default)
-2. Add `.prompt-sensei/` to your organization's gitignore standards
+1. Keep `PROMPT_SENSEI_STORE_RAW` unset (the default — no raw text stored)
+2. Add `~/.prompt-sensei/` to your backup exclusion rules if applicable
 3. Run `clear` at the end of each session if required by policy
+4. Review `scripts/observe.ts` to audit data collection before enabling the hook
 
 Prompt Sensei is designed to be safe to use in sensitive contexts with default settings.

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -1,0 +1,73 @@
+# Privacy
+
+## What is stored by default
+
+When observation mode is active, Prompt Sensei records the following per prompt:
+
+| Field       | Type     | Example                    |
+|-------------|----------|----------------------------|
+| `ts`        | string   | `"2026-04-25T14:32:10Z"`   |
+| `score`     | number   | `72`                       |
+| `grade`     | string   | `"Developing"`             |
+| `charCount` | number   | `148`                      |
+| `summary`   | string   | `"add explicit constraints"` |
+
+**Raw prompt text is never stored by default.**
+
+## What is never stored
+
+- Prompt content
+- File paths referenced in prompts
+- Code snippets from prompts
+- Anything that could identify a project, repo, or organization
+
+## Where data lives
+
+All session data is written to `.prompt-sensei/` in your project directory.
+
+```
+.prompt-sensei/
+└── session-2026-04-25.jsonl
+```
+
+This directory is listed in `.gitignore` and will not be committed to version control.
+
+## Opting in to full prompt storage
+
+If you want to store raw prompt text for your own analysis, you can call the observe script with `--store-prompt`:
+
+```bash
+npx ts-node scripts/observe.ts --score 72 --grade "Developing" --store-prompt --prompt "your prompt text"
+```
+
+This stores the prompt **locally only**. Nothing is sent externally.
+
+## Deleting your data
+
+Run:
+
+```bash
+npx ts-node scripts/clear.ts
+```
+
+Or delete the directory directly:
+
+```bash
+rm -rf .prompt-sensei/
+```
+
+There is no account to close, no server to notify, and no backup to remove. It's gone.
+
+## No telemetry
+
+Prompt Sensei contains no analytics, no error reporting, no usage tracking, and no network calls of any kind. The scripts are local Node.js executables. You can verify this by reading the source in `scripts/`.
+
+## Use in sensitive environments
+
+If you are working in an environment with strict data handling requirements (e.g., regulated industries, client work, confidential projects), you should:
+
+1. Keep `--store-prompt` disabled (the default)
+2. Add `.prompt-sensei/` to your organization's gitignore standards
+3. Run `clear` at the end of each session if required by policy
+
+Prompt Sensei is designed to be safe to use in sensitive contexts with default settings.

--- a/docs/scoring-rubric.md
+++ b/docs/scoring-rubric.md
@@ -1,0 +1,120 @@
+# Scoring Rubric
+
+Prompt Sensei scores every prompt on five criteria. Each criterion is worth 0–20 points. Maximum score: 100.
+
+---
+
+## 1. Intent Clarity (0–20)
+
+**Question:** Is it immediately obvious what you want Claude to do?
+
+A prompt with high intent clarity names the action, the target, and the desired outcome. A prompt with low clarity forces Claude to guess the goal before it can attempt it.
+
+| Score | Description |
+|-------|-------------|
+| 0–5   | Vague or ambiguous — multiple interpretations are possible |
+| 6–12  | Goal is implied but requires inference |
+| 13–20 | Action + target + outcome are all explicit |
+
+**Example (low):** `fix the bug`
+**Example (high):** `Fix the null pointer exception in auth/login.ts:47 — the function should return null when the user is not found, not throw`
+
+---
+
+## 2. Context Richness (0–20)
+
+**Question:** Does the prompt include the information Claude needs to act without asking follow-ups?
+
+Relevant context includes: error messages, file paths, what you've already tried, what the code is supposed to do, and any unusual constraints of the environment.
+
+| Score | Description |
+|-------|-------------|
+| 0–5   | No background provided |
+| 6–12  | Some context but key details are missing |
+| 13–20 | Relevant context included; Claude can start immediately |
+
+**Example (low):** `my tests are failing`
+**Example (high):** `My tests are failing after I renamed UserService to AccountService. Error: Cannot find module './UserService'. I've already updated the import in app.ts but the test at tests/auth.test.ts:22 still references the old name.`
+
+---
+
+## 3. Explicit Constraints (0–20)
+
+**Question:** Are restrictions and preferences stated upfront?
+
+Constraints save time. Without them, Claude may produce a solution that's technically correct but wrong for your context — using a banned library, touching files you didn't want changed, or adding abstractions you didn't ask for.
+
+| Score | Description |
+|-------|-------------|
+| 0–5   | No constraints mentioned |
+| 6–12  | Some constraints implied by context |
+| 13–20 | Constraints are clear and complete |
+
+**Common constraints worth stating:**
+- Dependency restrictions (`no new npm packages`)
+- File scope (`only modify src/utils/format.ts`)
+- Style preferences (`no classes, use functions`)
+- Safety boundaries (`don't modify the database schema`)
+- Output format (`show me a diff, don't apply it`)
+
+**Example (low):** `add input validation`
+**Example (high):** `Add input validation to the /register endpoint. Use zod (already installed). Don't modify the database schema or add new files — only change src/routes/auth.ts.`
+
+---
+
+## 4. Appropriate Scope (0–20)
+
+**Question:** Is this task sized for one productive exchange?
+
+Too large: "build me a full authentication system" — Claude will make dozens of undiscussed decisions. Too small: "add a semicolon on line 14" — no need for an AI. The sweet spot is a single coherent unit of work that produces a reviewable result.
+
+| Score | Description |
+|-------|-------------|
+| 0–5   | Scope is overwhelming or trivially small |
+| 6–12  | Workable but benefits from more/less decomposition |
+| 13–20 | Single coherent unit, right-sized for one exchange |
+
+**Signs of over-scope:** Multiple "and also..." clauses, outcomes that depend on architecture decisions you haven't made yet, tasks that would take a senior engineer more than a day.
+
+**Signs of under-scope:** The request is a lookup, a typo fix, or something you could do faster yourself.
+
+---
+
+## 5. Output Specification (0–20)
+
+**Question:** Does the prompt describe what success looks like?
+
+Without an output specification, Claude picks one. Specifying the output — a file to create, a test to pass, a behavior to demonstrate — makes the result reviewable and reduces revision cycles.
+
+| Score | Description |
+|-------|-------------|
+| 0–5   | No indication of expected output |
+| 6–12  | Expected output is implied |
+| 13–20 | Desired output is concrete and verifiable |
+
+**Example (low):** `make the login faster`
+**Example (high):** `Reduce the latency of the login endpoint so that the existing benchmark test in tests/perf/login.bench.ts passes. Target is under 200ms p95. Don't change the test.`
+
+---
+
+## Grade Scale
+
+| Score  | Grade      | Meaning                                          |
+|--------|------------|--------------------------------------------------|
+| 90–100 | Master     | Near-perfect — rare and worth recognizing        |
+| 75–89  | Skilled    | Minor gaps; most sessions will produce good work |
+| 55–74  | Developing | Clear gaps; specific fixes will move the needle  |
+| 35–54  | Beginner   | Multiple fundamentals missing                    |
+| 0–34   | Needs work | Start with Intent Clarity before anything else   |
+
+---
+
+## Which criteria move scores the most
+
+Based on common patterns in real Claude Code sessions:
+
+1. **Context Richness** → most common gap; error messages and file paths take seconds to add and save multiple follow-up rounds
+2. **Explicit Constraints** → prevents the most frustrating outcomes (unwanted changes, wrong libraries)
+3. **Output Specification** → makes results reviewable and reduces "that's not quite what I meant"
+
+Focus on these three first if you're below 75.

--- a/docs/scoring-rubric.md
+++ b/docs/scoring-rubric.md
@@ -1,120 +1,189 @@
 # Scoring Rubric
 
-Prompt Sensei scores every prompt on five criteria. Each criterion is worth 0–20 points. Maximum score: 100.
+Prompt Sensei scores prompts across seven dimensions, weighted by prompt stage. Not every dimension applies to every prompt — an exploration prompt is not a failed execution prompt.
 
 ---
 
-## 1. Intent Clarity (0–20)
+## Prompt Stages
 
-**Question:** Is it immediately obvious what you want Claude to do?
+Before scoring, classify the prompt:
 
-A prompt with high intent clarity names the action, the target, and the desired outcome. A prompt with low clarity forces Claude to guess the goal before it can attempt it.
+| Stage | Description |
+|---|---|
+| **Exploration** | Still figuring out the problem — "why is this broken?" |
+| **Diagnosis** | Has symptoms and evidence — "expected X, got Y" |
+| **Execution** | Wants implementation — imperative verb, specific scope |
+| **Verification** | Wants correctness checks — edge cases, tests, review |
+| **Reusable workflow** | Wants a repeatable template or process |
+
+**Dimensions scored per stage:**
+
+| Dimension | Exploration | Diagnosis | Execution | Verification |
+|---|---|---|---|---|
+| Goal Clarity | ✓ | ✓ | ✓ | ✓ |
+| Context Completeness | | ✓ | ✓ | ✓ |
+| Input Boundaries | | | ✓ | ✓ |
+| Constraints | | | ✓ | |
+| Output Format | | | ✓ | ✓ |
+| Verification | | | ✓ | ✓ |
+| Privacy/Safety | ✓ | ✓ | ✓ | ✓ |
+
+---
+
+## Dimension Definitions
+
+### 1. Goal Clarity (all stages)
+
+Is the desired outcome unambiguous?
+
+| Score | Description | Example |
+|---|---|---|
+| 1 | No discernible goal | "Fix it." "Make it better." |
+| 2 | Goal implied but ambiguous | "Clean up the auth code." |
+| 3 | Goal stated, no completion criteria | "Refactor the login function." |
+| 4 | Goal + one completion criterion | "Refactor login() to async/await, return typed result." |
+| 5 | Goal + criterion + success definition | "Refactor login() to async/await, return `Promise<UserResult>`, existing tests must pass." |
+
+**Before:** `fix the test`
+**After:** `Debug the failing Jest test in src/__tests__/auth.test.ts — expected redirect to /login, actual /dashboard.`
+
+---
+
+### 2. Context Completeness (Diagnosis, Execution, Verification)
+
+Did the user provide enough background to act without follow-up questions?
 
 | Score | Description |
-|-------|-------------|
-| 0–5   | Vague or ambiguous — multiple interpretations are possible |
-| 6–12  | Goal is implied but requires inference |
-| 13–20 | Action + target + outcome are all explicit |
+|---|---|
+| 1 | No context |
+| 2 | Problem area named, no specifics |
+| 3 | Some context; key details missing (no error output, no file path) |
+| 4 | Most context present; one or two details could help |
+| 5 | Error output, file paths, recent changes, and reproduction steps provided |
 
-**Example (low):** `fix the bug`
-**Example (high):** `Fix the null pointer exception in auth/login.ts:47 — the function should return null when the user is not found, not throw`
+**Before:** `my tests are failing`
+**After:** `Tests failing after renaming UserService → AccountService. Error: Cannot find module './UserService'. Updated import in app.ts but tests/auth.test.ts:22 still references old name.`
 
 ---
 
-## 2. Context Richness (0–20)
+### 3. Input Boundaries (Execution, Verification)
 
-**Question:** Does the prompt include the information Claude needs to act without asking follow-ups?
-
-Relevant context includes: error messages, file paths, what you've already tried, what the code is supposed to do, and any unusual constraints of the environment.
+Is it clear what Claude should read, use, or focus on?
 
 | Score | Description |
-|-------|-------------|
-| 0–5   | No background provided |
-| 6–12  | Some context but key details are missing |
-| 13–20 | Relevant context included; Claude can start immediately |
+|---|---|
+| 1 | No input scope stated |
+| 2 | General area mentioned ("the auth code") |
+| 3 | Module or file type named |
+| 4 | Specific file named |
+| 5 | File + function or line range named |
 
-**Example (low):** `my tests are failing`
-**Example (high):** `My tests are failing after I renamed UserService to AccountService. Error: Cannot find module './UserService'. I've already updated the import in app.ts but the test at tests/auth.test.ts:22 still references the old name.`
+**Before:** `fix the validation`
+**After:** `Fix input validation in the `validateUser()` function in `src/auth/validators.ts`.`
 
 ---
 
-## 3. Explicit Constraints (0–20)
+### 4. Constraints (Execution)
 
-**Question:** Are restrictions and preferences stated upfront?
-
-Constraints save time. Without them, Claude may produce a solution that's technically correct but wrong for your context — using a banned library, touching files you didn't want changed, or adding abstractions you didn't ask for.
+Are scope limits and tradeoffs stated?
 
 | Score | Description |
-|-------|-------------|
-| 0–5   | No constraints mentioned |
-| 6–12  | Some constraints implied by context |
-| 13–20 | Constraints are clear and complete |
+|---|---|
+| 1 | No constraints |
+| 2 | One vague constraint ("keep it simple") |
+| 3 | One clear constraint ("don't add new dependencies") |
+| 4 | Two or more clear constraints |
+| 5 | Constraints cover scope, dependencies, style, and safety |
 
-**Common constraints worth stating:**
-- Dependency restrictions (`no new npm packages`)
-- File scope (`only modify src/utils/format.ts`)
-- Style preferences (`no classes, use functions`)
-- Safety boundaries (`don't modify the database schema`)
-- Output format (`show me a diff, don't apply it`)
+Common constraints worth stating:
+- `Don't change the public API`
+- `No new npm packages`
+- `Existing tests must pass`
+- `Only modify src/auth/validators.ts`
+- `Prefer the minimal diff`
 
-**Example (low):** `add input validation`
-**Example (high):** `Add input validation to the /register endpoint. Use zod (already installed). Don't modify the database schema or add new files — only change src/routes/auth.ts.`
+**Before:** `add validation to the form`
+**After:** `Add input validation to the /register endpoint. Use zod (already installed). Don't add new files or modify the database schema. Only change src/routes/auth.ts.`
 
 ---
 
-## 4. Appropriate Scope (0–20)
+### 5. Output Format (Execution, Verification)
 
-**Question:** Is this task sized for one productive exchange?
-
-Too large: "build me a full authentication system" — Claude will make dozens of undiscussed decisions. Too small: "add a semicolon on line 14" — no need for an AI. The sweet spot is a single coherent unit of work that produces a reviewable result.
+Did the user specify how the response should be structured?
 
 | Score | Description |
-|-------|-------------|
-| 0–5   | Scope is overwhelming or trivially small |
-| 6–12  | Workable but benefits from more/less decomposition |
-| 13–20 | Single coherent unit, right-sized for one exchange |
+|---|---|
+| 1 | No output specification |
+| 2 | Output implied ("fix it" implies a code change) |
+| 3 | Format partially specified ("explain the issue") |
+| 4 | Format specified with a list |
+| 5 | Format fully specified with numbered structure |
 
-**Signs of over-scope:** Multiple "and also..." clauses, outcomes that depend on architecture decisions you haven't made yet, tasks that would take a senior engineer more than a day.
-
-**Signs of under-scope:** The request is a lookup, a typo fix, or something you could do faster yourself.
+**Before:** `why is login slow`
+**After:** `Diagnose the login endpoint latency. Return: 1. Root cause 2. Proposed fix 3. Estimated latency impact 4. Test command`
 
 ---
 
-## 5. Output Specification (0–20)
+### 6. Verification (Execution, Verification)
 
-**Question:** Does the prompt describe what success looks like?
-
-Without an output specification, Claude picks one. Specifying the output — a file to create, a test to pass, a behavior to demonstrate — makes the result reviewable and reduces revision cycles.
+Did the user ask how to check correctness?
 
 | Score | Description |
-|-------|-------------|
-| 0–5   | No indication of expected output |
-| 6–12  | Expected output is implied |
-| 13–20 | Desired output is concrete and verifiable |
+|---|---|
+| 1 | No mention of verification |
+| 2 | "Make sure it works" (no method) |
+| 3 | Asks for tests but no specifics |
+| 4 | Names the test file or test type |
+| 5 | Names test file + edge cases + test command |
 
-**Example (low):** `make the login faster`
-**Example (high):** `Reduce the latency of the login endpoint so that the existing benchmark test in tests/perf/login.bench.ts passes. Target is under 200ms p95. Don't change the test.`
-
----
-
-## Grade Scale
-
-| Score  | Grade      | Meaning                                          |
-|--------|------------|--------------------------------------------------|
-| 90–100 | Master     | Near-perfect — rare and worth recognizing        |
-| 75–89  | Skilled    | Minor gaps; most sessions will produce good work |
-| 55–74  | Developing | Clear gaps; specific fixes will move the needle  |
-| 35–54  | Beginner   | Multiple fundamentals missing                    |
-| 0–34   | Needs work | Start with Intent Clarity before anything else   |
+**Before:** `implement the auth refresh`
+**After:** `Implement token refresh in src/auth/refresh.ts. Verification: run `npm test src/auth/refresh.test.ts` — all existing tests must pass. Include edge cases: expired token, missing token, concurrent refresh.`
 
 ---
 
-## Which criteria move scores the most
+### 7. Privacy/Safety (all stages)
 
-Based on common patterns in real Claude Code sessions:
+Did the prompt avoid unnecessary sensitive data?
 
-1. **Context Richness** → most common gap; error messages and file paths take seconds to add and save multiple follow-up rounds
-2. **Explicit Constraints** → prevents the most frustrating outcomes (unwanted changes, wrong libraries)
-3. **Output Specification** → makes results reviewable and reduces "that's not quite what I meant"
+| Score | Description |
+|---|---|
+| 1 | Contains obvious secrets (API keys, passwords, tokens in plain text) |
+| 2 | Contains potentially sensitive data without clear need |
+| 3 | Borderline — personal data or internal URLs present |
+| 4 | Minor concerns (internal file paths, project names) |
+| 5 | No sensitive data, or sensitive data is clearly necessary and scoped |
 
-Focus on these three first if you're below 75.
+When in doubt, redact and note that you've done so: `[API key redacted]`.
+
+---
+
+## Composite Score
+
+Scores per dimension: 1–5. The composite is the average across applicable dimensions for the prompt's stage.
+
+**Grade labels:**
+
+| Score | Grade | What it means |
+|---|---|---|
+| 4.5–5.0 | Excellent | Execution-ready |
+| 3.5–4.4 | Good | Minor gaps, will still produce useful results |
+| 2.5–3.4 | Developing | Clear improvements available |
+| 1.5–2.4 | Early stage | Normal for exploration; add evidence when ready |
+| 1.0–1.4 | Needs work | Start with goal clarity |
+
+---
+
+## The Good Prompt Pattern
+
+For execution-stage prompts, this structure reliably hits 4.0+:
+
+```
+Goal:         What do you want Claude to do?
+Context:      What background is needed?
+Input:        What file, function, or code to focus on?
+Constraints:  What should Claude not touch?
+Output:       How should the response be structured?
+Verification: How should correctness be checked?
+```
+
+Not every prompt needs all six parts. Match depth to stage.

--- a/examples/debugging-journey.md
+++ b/examples/debugging-journey.md
@@ -1,0 +1,93 @@
+# Example: A Debugging Journey
+
+This example shows one prompt improving across three iterations. Each iteration applies the feedback from the previous score.
+
+---
+
+## Iteration 1 — First attempt
+
+**Prompt:**
+> fix the login bug
+
+**Score: 12/100 — Needs work**
+
+| Criterion            | Score |
+|----------------------|-------|
+| Intent Clarity       | 4/20  |
+| Context Richness     | 2/20  |
+| Explicit Constraints | 2/20  |
+| Appropriate Scope    | 2/20  |
+| Output Specification | 2/20  |
+
+**Feedback:**
+- **Intent Clarity**: "fix" + "bug" tells Claude almost nothing. What kind of bug? What is the wrong behavior?
+- **Context Richness**: No error, no file, no reproduction steps. Claude will ask 3–4 follow-up questions before doing anything useful.
+
+---
+
+## Iteration 2 — Added context
+
+**Prompt:**
+> The login form is submitting but users aren't being redirected after successful login. There's no error in the console. Fix it.
+
+**Score: 48/100 — Beginner**
+
+| Criterion            | Score |
+|----------------------|-------|
+| Intent Clarity       | 14/20 |
+| Context Richness     | 8/20  |
+| Explicit Constraints | 4/20  |
+| Appropriate Scope    | 12/20 |
+| Output Specification | 10/20 |
+
+**Feedback:**
+- **Context Richness**: Better — symptom is clear. Still missing: which file handles the redirect? Which framework (Next.js, React Router, plain JS)?
+- **Explicit Constraints**: Should Claude add logging? Touch the auth middleware? Modify tests?
+
+---
+
+## Iteration 3 — Full prompt
+
+**Prompt:**
+> After a successful login, users should be redirected to `/dashboard` but they stay on the `/login` page. No console errors. The login logic is in `src/pages/login.tsx` — the `handleSubmit` function calls `signIn()` from next-auth and then should call `router.push('/dashboard')`. I think the issue is that `router.push` runs before `signIn` resolves. Fix the async handling in `handleSubmit` only — don't change the auth config, middleware, or tests.
+
+**Score: 91/100 — Master**
+
+| Criterion            | Score |
+|----------------------|-------|
+| Intent Clarity       | 19/20 |
+| Context Richness     | 18/20 |
+| Explicit Constraints | 18/20 |
+| Appropriate Scope    | 18/20 |
+| Output Specification | 18/20 |
+
+**Feedback:**
+- Near-perfect. Claude can go directly to the fix.
+- Minor gap: "Output Specification" — could mention whether a test update is expected, but the constraint "don't change tests" makes this acceptable.
+
+---
+
+## What changed
+
+| Version | Key addition                           | Score jump |
+|---------|----------------------------------------|------------|
+| v1 → v2 | Named the symptom                      | +36        |
+| v2 → v3 | Added file path, root cause hypothesis, and constraints | +43 |
+
+The largest gains came from **context** (knowing where to look) and **constraints** (knowing what not to touch). Both took under 30 seconds to add.
+
+---
+
+## The pattern
+
+Good debugging prompts tend to follow this structure:
+
+```
+[Symptom]: What is visibly wrong
+[Expected behavior]: What should happen instead
+[Location]: File + function where the issue likely lives
+[Hypothesis]: What you think might be causing it (even if unsure)
+[Constraints]: What Claude should not touch
+```
+
+You don't need all five parts every time, but having them ready makes the difference between one round and five.

--- a/examples/debugging-journey.md
+++ b/examples/debugging-journey.md
@@ -1,93 +1,169 @@
 # Example: A Debugging Journey
 
-This example shows one prompt improving across three iterations. Each iteration applies the feedback from the previous score.
+This example follows one developer improving the same prompt across four iterations over two days. Each iteration applies one habit from the previous session's feedback.
+
+The scenario: a Jest test is failing after adding refresh-token support. The developer is using Claude Code to debug it.
 
 ---
 
-## Iteration 1 — First attempt
+## Day 1, Attempt 1 — Exploration
 
 **Prompt:**
-> fix the login bug
+> fix this test
 
-**Score: 12/100 — Needs work**
+**Stage:** Exploration
+**Score:** 1.5/5 (as Exploration) · 1.2/5 (if Execution-ready)
 
-| Criterion            | Score |
-|----------------------|-------|
-| Intent Clarity       | 4/20  |
-| Context Richness     | 2/20  |
-| Explicit Constraints | 2/20  |
-| Appropriate Scope    | 2/20  |
-| Output Specification | 2/20  |
+| Dimension | Score | Note |
+|---|---|---|
+| Goal Clarity | 2/5 | Implies debugging help but no goal stated |
+| Privacy/Safety | 5/5 | No sensitive data |
 
 **Feedback:**
-- **Intent Clarity**: "fix" + "bug" tells Claude almost nothing. What kind of bug? What is the wrong behavior?
-- **Context Richness**: No error, no file, no reproduction steps. Claude will ask 3–4 follow-up questions before doing anything useful.
+This is a normal starting point when you first notice something is wrong. The problem is that "this test" could be any of the hundreds of tests in the project, and "fix" does not describe whether you want a diagnosis, a patch, or an explanation.
+
+**One habit to practice next:**
+Name the specific failing test and describe what you expected vs. what actually happened.
 
 ---
 
-## Iteration 2 — Added context
+## Day 1, Attempt 2 — Diagnosis
+
+After getting a partial response, the developer now has the error output. They try again.
 
 **Prompt:**
-> The login form is submitting but users aren't being redirected after successful login. There's no error in the console. Fix it.
+> A Jest test is failing. Expected /login, actual /dashboard.
 
-**Score: 48/100 — Beginner**
+**Stage:** Diagnosis
+**Score:** 2.8/5
 
-| Criterion            | Score |
-|----------------------|-------|
-| Intent Clarity       | 14/20 |
-| Context Richness     | 8/20  |
-| Explicit Constraints | 4/20  |
-| Appropriate Scope    | 12/20 |
-| Output Specification | 10/20 |
+| Dimension | Score | Note |
+|---|---|---|
+| Goal Clarity | 3/5 | Symptom is clear; goal (debug? fix? explain?) is not |
+| Context Completeness | 2/5 | No file, no test name, no recent change context |
+| Privacy/Safety | 5/5 | Clean |
 
 **Feedback:**
-- **Context Richness**: Better — symptom is clear. Still missing: which file handles the redirect? Which framework (Next.js, React Router, plain JS)?
-- **Explicit Constraints**: Should Claude add logging? Touch the auth middleware? Modify tests?
+Meaningful progress. You added expected vs. actual behavior — that's the most valuable single addition for any debugging prompt. Claude can now at least understand the failure.
+
+What's still missing: which file? Which test? What changed recently that might have caused this?
+
+**One habit to practice next:**
+Add the file path and the recent change that might be related.
 
 ---
 
-## Iteration 3 — Full prompt
+## Day 2, Attempt 3 — Execution
+
+The developer now knows the relevant file and suspects a recent change.
 
 **Prompt:**
-> After a successful login, users should be redirected to `/dashboard` but they stay on the `/login` page. No console errors. The login logic is in `src/pages/login.tsx` — the `handleSubmit` function calls `signIn()` from next-auth and then should call `router.push('/dashboard')`. I think the issue is that `router.push` runs before `signIn` resolves. Fix the async handling in `handleSubmit` only — don't change the auth config, middleware, or tests.
+> Please debug this failing Jest test. Expected redirect to /login, actual /dashboard.
+> Related file: src/__tests__/auth.test.ts
+> Recent change: added refresh-token support.
+> Do not refactor the whole auth flow.
 
-**Score: 91/100 — Master**
+**Stage:** Execution
+**Score:** 3.6/5
 
-| Criterion            | Score |
-|----------------------|-------|
-| Intent Clarity       | 19/20 |
-| Context Richness     | 18/20 |
-| Explicit Constraints | 18/20 |
-| Appropriate Scope    | 18/20 |
-| Output Specification | 18/20 |
+| Dimension | Score | Note |
+|---|---|---|
+| Goal Clarity | 4/5 | Clear outcome |
+| Context Completeness | 3/5 | Recent change mentioned; error text still missing |
+| Input Boundaries | 3/5 | Test file named; specific test case not named |
+| Constraints | 3/5 | One constraint ("don't refactor") |
+| Output Format | 2/5 | No structure specified |
+| Verification | 1/5 | Not mentioned |
+| Privacy/Safety | 5/5 | Clean |
 
 **Feedback:**
-- Near-perfect. Claude can go directly to the fix.
-- Minor gap: "Output Specification" — could mention whether a test update is expected, but the constraint "don't change tests" makes this acceptable.
+This is a solid debugging prompt. Claude can work with this and will probably get to the root cause. Two things that would make the response more useful: specifying the output format (root cause, fix, test command) and adding a verification step.
+
+**One habit to practice next:**
+End every debugging prompt with "Return: 1. Root cause 2. Minimal fix 3. Test command."
+
+---
+
+## Day 2, Attempt 4 — Execution (polished)
+
+**Prompt:**
+> Please debug this failing Jest test.
+>
+> Goal:
+>   Find why unauthenticated users are redirected to /dashboard instead of /login.
+>
+> Context:
+>   - Stack: TypeScript, React, Jest
+>   - Recent change: added refresh-token support
+>   - Related files:
+>     - src/middleware/auth.ts
+>     - src/routes/ProtectedRoute.tsx
+>     - src/__tests__/auth.test.ts
+>
+> Expected:
+>   If the user has no access token and no refresh token, redirect to /login.
+>
+> Actual:
+>   The test receives /dashboard.
+>
+> Constraints:
+>   - Do not refactor the whole auth flow
+>   - Prefer the smallest safe fix
+>   - If the test expectation is wrong, explain why before changing it
+>
+> Return:
+>   1. Root cause
+>   2. Proposed fix
+>   3. Patch summary
+>   4. Test command
+>   5. Edge cases to verify
+
+**Stage:** Execution
+**Score:** 4.7/5 — Excellent
+
+| Dimension | Score | Note |
+|---|---|---|
+| Goal Clarity | 5/5 | Outcome is specific and verifiable |
+| Context Completeness | 5/5 | Stack, change, files, expected, actual |
+| Input Boundaries | 4/5 | Three files named (could specify which functions) |
+| Constraints | 5/5 | Three constraints, all clear |
+| Output Format | 5/5 | Numbered return structure |
+| Verification | 4/5 | Test command + edge cases requested |
+| Privacy/Safety | 5/5 | No sensitive data |
+
+**Feedback:**
+Excellent. This is execution-ready. Claude can go directly to the fix with no follow-up questions. The structured return format makes the response easy to review and act on.
 
 ---
 
 ## What changed
 
-| Version | Key addition                           | Score jump |
-|---------|----------------------------------------|------------|
-| v1 → v2 | Named the symptom                      | +36        |
-| v2 → v3 | Added file path, root cause hypothesis, and constraints | +43 |
+| Attempt | Key addition | Score jump |
+|---|---|---|
+| 1 → 2 | Expected vs. actual behavior | +1.3 |
+| 2 → 3 | File name + constraint | +0.8 |
+| 3 → 4 | Output structure + verification | +1.1 |
 
-The largest gains came from **context** (knowing where to look) and **constraints** (knowing what not to touch). Both took under 30 seconds to add.
+The three biggest gains came from:
+1. Adding expected vs. actual (most impactful single addition for any debugging prompt)
+2. Naming the specific file
+3. Specifying the return format
+
+Each of those took under 30 seconds to add. The cumulative effect was the difference between a response that required 3 follow-up rounds and one that produced the fix in a single exchange.
 
 ---
 
 ## The pattern
 
-Good debugging prompts tend to follow this structure:
+Execution-ready debugging prompts tend to include:
 
 ```
-[Symptom]: What is visibly wrong
-[Expected behavior]: What should happen instead
-[Location]: File + function where the issue likely lives
-[Hypothesis]: What you think might be causing it (even if unsure)
-[Constraints]: What Claude should not touch
+Goal:        What behavior is wrong?
+Context:     Stack, recent change, related files
+Expected:    What should happen?
+Actual:      What actually happens?
+Constraints: What should Claude not touch?
+Return:      Root cause · Fix · Test command · Edge cases
 ```
 
-You don't need all five parts every time, but having them ready makes the difference between one round and five.
+Start where you are. Add one element at a time. That's how this prompt went from 1.5 to 4.7.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "prompt-sensei",
+  "version": "0.1.0",
+  "description": "A quiet, local-first prompt mentor for engineers using AI coding tools",
+  "type": "commonjs",
+  "scripts": {
+    "build": "tsc",
+    "observe": "node dist/scripts/observe.js",
+    "report": "node dist/scripts/report.js",
+    "clear-data": "node dist/scripts/clear.js"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.0.0"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "keywords": [
+    "claude-code",
+    "prompt-engineering",
+    "ai-coding",
+    "developer-tools",
+    "prompt-coach",
+    "local-first",
+    "engineering-productivity",
+    "ai-agents"
+  ],
+  "license": "Apache-2.0",
+  "author": "Chengzhong Wei"
+}

--- a/scripts/clear.ts
+++ b/scripts/clear.ts
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+/**
+ * Delete all local session data.
+ * Usage: npx ts-node scripts/clear.ts [--force]
+ */
+
+import fs from "fs";
+import path from "path";
+import readline from "readline";
+
+const DATA_DIR = path.join(process.cwd(), ".prompt-sensei");
+
+function countSessions(): { files: number; entries: number } {
+  if (!fs.existsSync(DATA_DIR)) return { files: 0, entries: 0 };
+  const files = fs
+    .readdirSync(DATA_DIR)
+    .filter((f) => f.startsWith("session-") && f.endsWith(".jsonl"));
+
+  let entries = 0;
+  for (const file of files) {
+    const lines = fs
+      .readFileSync(path.join(DATA_DIR, file), "utf8")
+      .split("\n")
+      .filter(Boolean);
+    entries += lines.length;
+  }
+  return { files: files.length, entries };
+}
+
+function deleteAll() {
+  if (!fs.existsSync(DATA_DIR)) {
+    console.log("Nothing to clear — no session data found.");
+    return;
+  }
+  const files = fs
+    .readdirSync(DATA_DIR)
+    .filter((f) => f.startsWith("session-") && f.endsWith(".jsonl"));
+  for (const file of files) {
+    fs.unlinkSync(path.join(DATA_DIR, file));
+  }
+  console.log(`Cleared ${files.length} session file(s). Fresh start.`);
+}
+
+function main() {
+  const force = process.argv.includes("--force");
+  const { files, entries } = countSessions();
+
+  if (files === 0) {
+    console.log("Nothing to clear — no session data found.");
+    return;
+  }
+
+  if (force) {
+    deleteAll();
+    return;
+  }
+
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  rl.question(
+    `Delete ${files} session file(s) containing ${entries} prompt entries? [y/N] `,
+    (answer) => {
+      rl.close();
+      if (answer.toLowerCase() === "y") {
+        deleteAll();
+      } else {
+        console.log("Aborted. Data preserved.");
+      }
+    }
+  );
+}
+
+main();

--- a/scripts/clear.ts
+++ b/scripts/clear.ts
@@ -1,76 +1,90 @@
 #!/usr/bin/env node
 /**
- * Delete all local session data.
- * Usage: npx ts-node scripts/clear.ts [--force]
+ * Delete local session data.
+ * Usage: clear.js [--force] [--all]
+ *
+ * --force   Skip confirmation prompt
+ * --all     Also delete config.json (resets consent)
  */
 
-import fs from "fs";
-import path from "path";
-import readline from "readline";
+import { existsSync, unlinkSync, statSync, readFileSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+import * as readline from "readline";
 
-const DATA_DIR = path.join(process.cwd(), ".prompt-sensei");
+const DATA_DIR = join(homedir(), ".prompt-sensei");
+const EVENTS_FILE = join(DATA_DIR, "events.jsonl");
+const CONFIG_FILE = join(DATA_DIR, "config.json");
 
-function countSessions(): { files: number; entries: number } {
-  if (!fs.existsSync(DATA_DIR)) return { files: 0, entries: 0 };
-  const files = fs
-    .readdirSync(DATA_DIR)
-    .filter((f) => f.startsWith("session-") && f.endsWith(".jsonl"));
-
-  let entries = 0;
-  for (const file of files) {
-    const lines = fs
-      .readFileSync(path.join(DATA_DIR, file), "utf8")
-      .split("\n")
-      .filter(Boolean);
-    entries += lines.length;
-  }
-  return { files: files.length, entries };
+function countEntries(): number {
+  if (!existsSync(EVENTS_FILE)) return 0;
+  return readFileSync(EVENTS_FILE, "utf8")
+    .split("\n")
+    .filter((l) => l.trim() && l.includes("prompt-observed")).length;
 }
 
-function deleteAll() {
-  if (!fs.existsSync(DATA_DIR)) {
-    console.log("Nothing to clear — no session data found.");
-    return;
+function deleteData(all: boolean): void {
+  let deleted = 0;
+
+  if (existsSync(EVENTS_FILE)) {
+    unlinkSync(EVENTS_FILE);
+    deleted++;
+    console.log(`Deleted: ${EVENTS_FILE}`);
   }
-  const files = fs
-    .readdirSync(DATA_DIR)
-    .filter((f) => f.startsWith("session-") && f.endsWith(".jsonl"));
-  for (const file of files) {
-    fs.unlinkSync(path.join(DATA_DIR, file));
+
+  if (all && existsSync(CONFIG_FILE)) {
+    unlinkSync(CONFIG_FILE);
+    deleted++;
+    console.log(`Deleted: ${CONFIG_FILE}`);
+    console.log("Consent reset. Prompt Sensei will ask for consent again on next use.");
   }
-  console.log(`Cleared ${files.length} session file(s). Fresh start.`);
+
+  if (deleted === 0) {
+    console.log("Nothing to delete — no data found.");
+  } else {
+    console.log("Done. Fresh start.");
+  }
 }
 
-function main() {
+async function confirm(question: string): Promise<boolean> {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => {
+      rl.close();
+      resolve(answer.toLowerCase() === "y");
+    });
+  });
+}
+
+async function main(): Promise<void> {
   const force = process.argv.includes("--force");
-  const { files, entries } = countSessions();
+  const all = process.argv.includes("--all");
 
-  if (files === 0) {
+  const entries = countEntries();
+
+  if (entries === 0 && !existsSync(CONFIG_FILE)) {
     console.log("Nothing to clear — no session data found.");
     return;
   }
 
   if (force) {
-    deleteAll();
+    deleteData(all);
     return;
   }
 
-  const rl = readline.createInterface({
-    input: process.stdin,
-    output: process.stdout,
-  });
-
-  rl.question(
-    `Delete ${files} session file(s) containing ${entries} prompt entries? [y/N] `,
-    (answer) => {
-      rl.close();
-      if (answer.toLowerCase() === "y") {
-        deleteAll();
-      } else {
-        console.log("Aborted. Data preserved.");
-      }
-    }
+  const what = all ? "events and config (resets consent)" : "events";
+  const ok = await confirm(
+    `Delete ${entries} prompt entries (${what})? [y/N] `
   );
+
+  if (ok) {
+    deleteData(all);
+  } else {
+    console.log("Aborted. Data preserved.");
+  }
 }
 
-main();
+main().catch((err) => {
+  process.stderr.write(`clear error: ${err}\n`);
+  process.exit(1);
+});

--- a/scripts/observe.ts
+++ b/scripts/observe.ts
@@ -1,29 +1,54 @@
 #!/usr/bin/env node
 /**
- * Record a prompt entry to the local session store.
- * Usage: npx ts-node scripts/observe.ts --score 72 --grade "Developing" [--summary "top tip text"]
+ * Record a prompt observation to the local session store.
  *
- * Raw prompt text is NOT stored by default. Only metadata (score, grade, timestamp, char count)
- * is written. Pass --store-prompt to opt in to full text storage.
+ * Usage:
+ *   observe.js --init
+ *   observe.js --stage execution --score 3.8 --task-type debugging --flags missing-context,no-constraints
+ *
+ * Raw prompt text is never stored. Only metadata: timestamp, stage, task type,
+ * score, and lightweight flags. A SHA-256 hash of the prompt may be stored
+ * if the prompt text is provided via stdin and hashing is enabled.
+ *
+ * Storage: ~/.prompt-sensei/events.jsonl
  */
 
-import fs from "fs";
-import path from "path";
-import os from "os";
+import { createHash } from "crypto";
+import { mkdirSync, appendFileSync, writeFileSync, existsSync, readFileSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+import * as readline from "readline";
 
-const DATA_DIR = path.join(process.cwd(), ".prompt-sensei");
-const SESSION_FILE = path.join(
-  DATA_DIR,
-  `session-${new Date().toISOString().slice(0, 10)}.jsonl`
-);
+const DATA_DIR = join(homedir(), ".prompt-sensei");
+const EVENTS_FILE = join(DATA_DIR, "events.jsonl");
+const CONFIG_FILE = join(DATA_DIR, "config.json");
 
-interface PromptEntry {
-  ts: string;
-  score: number;
-  grade: string;
-  charCount?: number;
-  summary?: string;
-  prompt?: string;
+// Patterns for redacting sensitive data before hashing
+const REDACT_PATTERNS: Array<[RegExp, string]> = [
+  [/\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g, "[EMAIL]"],
+  [/\b(sk-|sk-ant-|ghp_|github_pat_|xox[baprs]-)[A-Za-z0-9\-_]{10,}/g, "[API_KEY]"],
+  [/\b(password|passwd|secret|token|api_?key)\s*[:=]\s*\S+/gi, "[CREDENTIAL]"],
+  [/-----BEGIN [A-Z ]+-----[\s\S]+?-----END [A-Z ]+-----/g, "[PRIVATE_KEY]"],
+  [/https?:\/\/[^\s]+\?[^\s]+/g, "[URL_WITH_PARAMS]"],
+];
+
+function redact(text: string): string {
+  let result = text;
+  for (const [pattern, replacement] of REDACT_PATTERNS) {
+    result = result.replace(pattern, replacement);
+  }
+  return result;
+}
+
+function hashPrompt(text: string): string {
+  const redacted = redact(text);
+  return createHash("sha256").update(redacted).digest("hex").slice(0, 16);
+}
+
+function ensureDataDir(): void {
+  if (!existsSync(DATA_DIR)) {
+    mkdirSync(DATA_DIR, { recursive: true });
+  }
 }
 
 function parseArgs(argv: string[]): Record<string, string | boolean> {
@@ -33,7 +58,7 @@ function parseArgs(argv: string[]): Record<string, string | boolean> {
     if (arg.startsWith("--")) {
       const key = arg.slice(2);
       const next = argv[i + 1];
-      if (next && !next.startsWith("--")) {
+      if (next !== undefined && !next.startsWith("--")) {
         result[key] = next;
         i++;
       } else {
@@ -44,36 +69,117 @@ function parseArgs(argv: string[]): Record<string, string | boolean> {
   return result;
 }
 
-function main() {
+interface Config {
+  v: number;
+  consentGiven: boolean;
+  consentAt: string;
+  storeRaw: boolean;
+}
+
+function loadConfig(): Config | null {
+  if (!existsSync(CONFIG_FILE)) return null;
+  try {
+    return JSON.parse(readFileSync(CONFIG_FILE, "utf8")) as Config;
+  } catch {
+    return null;
+  }
+}
+
+function saveConfig(config: Config): void {
+  ensureDataDir();
+  writeFileSync(CONFIG_FILE, JSON.stringify(config, null, 2) + "\n", "utf8");
+}
+
+interface PromptEvent {
+  v: 1;
+  ts: string;
+  type: "session-start" | "prompt-observed";
+  stage?: string;
+  taskType?: string;
+  score?: number;
+  flags?: string[];
+  promptHash?: string;
+}
+
+function appendEvent(event: PromptEvent): void {
+  ensureDataDir();
+  appendFileSync(EVENTS_FILE, JSON.stringify(event) + "\n", "utf8");
+}
+
+async function readStdin(): Promise<string> {
+  if (process.stdin.isTTY) return "";
+  const rl = readline.createInterface({ input: process.stdin });
+  const lines: string[] = [];
+  for await (const line of rl) {
+    lines.push(line);
+  }
+  return lines.join("\n");
+}
+
+async function main(): Promise<void> {
   const args = parseArgs(process.argv);
 
-  const score = Number(args["score"]);
-  const grade = String(args["grade"] ?? "Unknown");
-  const summary = args["summary"] ? String(args["summary"]) : undefined;
-  const charCount = args["char-count"] ? Number(args["char-count"]) : undefined;
-  const storePrompt = args["store-prompt"] === true;
-  const promptText = storePrompt && args["prompt"] ? String(args["prompt"]) : undefined;
+  if (args["init"] === true) {
+    const config = loadConfig();
+    if (!config) {
+      // First run — consent not yet given; SKILL.md handles the consent prompt
+      // This --init just ensures the data directory exists
+      ensureDataDir();
+      console.log(`Data directory ready: ${DATA_DIR}`);
+      return;
+    }
 
-  if (isNaN(score) || score < 0 || score > 100) {
-    console.error("Error: --score must be a number between 0 and 100");
+    appendEvent({
+      v: 1,
+      ts: new Date().toISOString(),
+      type: "session-start",
+    });
+
+    saveConfig({
+      ...config,
+      consentGiven: true,
+      consentAt: config.consentAt ?? new Date().toISOString(),
+    });
+
+    console.log("Session started.");
+    return;
+  }
+
+  // Record a prompt observation
+  const stage = args["stage"] ? String(args["stage"]) : "unknown";
+  const score = args["score"] ? parseFloat(String(args["score"])) : undefined;
+  const taskType = args["task-type"] ? String(args["task-type"]) : "other";
+  const flagsRaw = args["flags"] ? String(args["flags"]) : "";
+  const flags = flagsRaw ? flagsRaw.split(",").map((f) => f.trim()).filter(Boolean) : [];
+
+  // Optionally hash the prompt from stdin (never store raw text)
+  let promptHash: string | undefined;
+  const storeRaw = process.env["PROMPT_SENSEI_STORE_RAW"] === "1";
+  if (!storeRaw) {
+    const stdinText = await readStdin();
+    if (stdinText.trim()) {
+      promptHash = hashPrompt(stdinText);
+    }
+  }
+
+  if (score !== undefined && (isNaN(score) || score < 0 || score > 5)) {
+    process.stderr.write("Error: --score must be between 0 and 5\n");
     process.exit(1);
   }
 
-  if (!fs.existsSync(DATA_DIR)) {
-    fs.mkdirSync(DATA_DIR, { recursive: true });
-  }
-
-  const entry: PromptEntry = {
+  appendEvent({
+    v: 1,
     ts: new Date().toISOString(),
-    score,
-    grade,
-    ...(charCount !== undefined && { charCount }),
-    ...(summary && { summary }),
-    ...(promptText && { prompt: promptText }),
-  };
-
-  fs.appendFileSync(SESSION_FILE, JSON.stringify(entry) + os.EOL, "utf8");
-  console.log(`Recorded: score=${score} grade=${grade} -> ${SESSION_FILE}`);
+    type: "prompt-observed",
+    stage,
+    taskType,
+    ...(score !== undefined && { score }),
+    ...(flags.length > 0 && { flags }),
+    ...(promptHash && { promptHash }),
+  });
 }
 
-main();
+main().catch((err) => {
+  process.stderr.write(`observe error: ${err}\n`);
+  process.exit(1);
+});

--- a/scripts/observe.ts
+++ b/scripts/observe.ts
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+/**
+ * Record a prompt entry to the local session store.
+ * Usage: npx ts-node scripts/observe.ts --score 72 --grade "Developing" [--summary "top tip text"]
+ *
+ * Raw prompt text is NOT stored by default. Only metadata (score, grade, timestamp, char count)
+ * is written. Pass --store-prompt to opt in to full text storage.
+ */
+
+import fs from "fs";
+import path from "path";
+import os from "os";
+
+const DATA_DIR = path.join(process.cwd(), ".prompt-sensei");
+const SESSION_FILE = path.join(
+  DATA_DIR,
+  `session-${new Date().toISOString().slice(0, 10)}.jsonl`
+);
+
+interface PromptEntry {
+  ts: string;
+  score: number;
+  grade: string;
+  charCount?: number;
+  summary?: string;
+  prompt?: string;
+}
+
+function parseArgs(argv: string[]): Record<string, string | boolean> {
+  const result: Record<string, string | boolean> = {};
+  for (let i = 2; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg.startsWith("--")) {
+      const key = arg.slice(2);
+      const next = argv[i + 1];
+      if (next && !next.startsWith("--")) {
+        result[key] = next;
+        i++;
+      } else {
+        result[key] = true;
+      }
+    }
+  }
+  return result;
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+
+  const score = Number(args["score"]);
+  const grade = String(args["grade"] ?? "Unknown");
+  const summary = args["summary"] ? String(args["summary"]) : undefined;
+  const charCount = args["char-count"] ? Number(args["char-count"]) : undefined;
+  const storePrompt = args["store-prompt"] === true;
+  const promptText = storePrompt && args["prompt"] ? String(args["prompt"]) : undefined;
+
+  if (isNaN(score) || score < 0 || score > 100) {
+    console.error("Error: --score must be a number between 0 and 100");
+    process.exit(1);
+  }
+
+  if (!fs.existsSync(DATA_DIR)) {
+    fs.mkdirSync(DATA_DIR, { recursive: true });
+  }
+
+  const entry: PromptEntry = {
+    ts: new Date().toISOString(),
+    score,
+    grade,
+    ...(charCount !== undefined && { charCount }),
+    ...(summary && { summary }),
+    ...(promptText && { prompt: promptText }),
+  };
+
+  fs.appendFileSync(SESSION_FILE, JSON.stringify(entry) + os.EOL, "utf8");
+  console.log(`Recorded: score=${score} grade=${grade} -> ${SESSION_FILE}`);
+}
+
+main();

--- a/scripts/report.ts
+++ b/scripts/report.ts
@@ -1,131 +1,206 @@
 #!/usr/bin/env node
 /**
- * Generate a report from all local session data.
- * Usage: npx ts-node scripts/report.ts [--days 7]
+ * Generate a session report from local observation data.
+ * Usage: report.js [--days 7]
+ *
+ * Reads ~/.prompt-sensei/events.jsonl and prints a Markdown report to stdout.
  */
 
-import fs from "fs";
-import path from "path";
+import { readFileSync, existsSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
 
-const DATA_DIR = path.join(process.cwd(), ".prompt-sensei");
+const DATA_DIR = join(homedir(), ".prompt-sensei");
+const EVENTS_FILE = join(DATA_DIR, "events.jsonl");
 
-interface PromptEntry {
+interface PromptEvent {
+  v: number;
   ts: string;
-  score: number;
-  grade: string;
-  charCount?: number;
-  summary?: string;
+  type: string;
+  stage?: string;
+  taskType?: string;
+  score?: number;
+  flags?: string[];
 }
 
-function gradeLabel(score: number): string {
-  if (score >= 90) return "Master";
-  if (score >= 75) return "Skilled";
-  if (score >= 55) return "Developing";
-  if (score >= 35) return "Beginner";
-  return "Needs work";
-}
-
-function bar(value: number, max: number, width = 20): string {
-  const filled = Math.round((value / max) * width);
-  return "█".repeat(filled) + "░".repeat(width - filled);
-}
-
-function loadEntries(days: number): PromptEntry[] {
-  if (!fs.existsSync(DATA_DIR)) return [];
+function loadEvents(days: number): PromptEvent[] {
+  if (!existsSync(EVENTS_FILE)) return [];
 
   const cutoff = new Date();
   cutoff.setDate(cutoff.getDate() - days);
 
-  const files = fs
-    .readdirSync(DATA_DIR)
-    .filter((f) => f.startsWith("session-") && f.endsWith(".jsonl"))
-    .sort();
+  const lines = readFileSync(EVENTS_FILE, "utf8")
+    .split("\n")
+    .filter(Boolean);
 
-  const entries: PromptEntry[] = [];
-  for (const file of files) {
-    const lines = fs
-      .readFileSync(path.join(DATA_DIR, file), "utf8")
-      .split("\n")
-      .filter(Boolean);
-    for (const line of lines) {
-      try {
-        const entry = JSON.parse(line) as PromptEntry;
-        if (new Date(entry.ts) >= cutoff) {
-          entries.push(entry);
-        }
-      } catch {
-        // skip malformed lines
+  const events: PromptEvent[] = [];
+  for (const line of lines) {
+    try {
+      const event = JSON.parse(line) as PromptEvent;
+      if (
+        event.type === "prompt-observed" &&
+        new Date(event.ts) >= cutoff
+      ) {
+        events.push(event);
       }
+    } catch {
+      // skip malformed lines
     }
   }
-  return entries;
+  return events;
 }
 
-function main() {
+function avg(nums: number[]): number {
+  if (nums.length === 0) return 0;
+  return nums.reduce((a, b) => a + b, 0) / nums.length;
+}
+
+function gradeLabel(score: number): string {
+  if (score >= 4.5) return "Excellent";
+  if (score >= 3.5) return "Good";
+  if (score >= 2.5) return "Developing";
+  if (score >= 1.5) return "Early stage";
+  return "Needs work";
+}
+
+function topN<T>(map: Map<T, number>, n: number): Array<[T, number]> {
+  return [...map.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, n);
+}
+
+function sparkline(scores: number[]): string {
+  const chars = ["▁", "▂", "▃", "▄", "▅", "▆", "▇", "█"];
+  return scores
+    .map((s) => chars[Math.min(Math.floor((s / 5) * chars.length), chars.length - 1)])
+    .join("");
+}
+
+function generateEncouragement(
+  avgScore: number,
+  trend: number,
+  topStage: string,
+  topFlags: Array<[string, number]>
+): string {
+  const lines: string[] = [];
+
+  if (trend > 0.2) {
+    lines.push("Your scores are trending upward. The practice is working.");
+  } else if (trend < -0.2) {
+    lines.push(
+      "Your scores dipped recently. That can happen when tasks get harder — keep going."
+    );
+  } else {
+    lines.push("Your scores are steady. Ready to push to the next level?");
+  }
+
+  if (avgScore >= 4.5) {
+    lines.push("You are consistently writing execution-ready prompts. That's a real skill.");
+  } else if (avgScore >= 3.5) {
+    lines.push(
+      "You are writing good prompts. One more habit — verification steps — will take you to the next level."
+    );
+  } else if (avgScore >= 2.5) {
+    lines.push(
+      "You are in the developing stage. The gap between where you are and 'good' is smaller than it feels."
+    );
+  } else {
+    lines.push(
+      "Every expert started with exploration prompts. Focus on one dimension at a time."
+    );
+  }
+
+  if (topFlags.length > 0) {
+    const [topFlag] = topFlags[0];
+    const flagHints: Record<string, string> = {
+      "missing-context": "Try adding the error message or stack trace to every debugging prompt.",
+      "no-constraints": "Add at least one constraint to implementation prompts ('don't change the API', 'no new deps').",
+      "no-verification": "End implementation prompts with 'Return: test command and edge cases to verify.'",
+      "no-output-format": "Specify the format: 'Return: 1. Root cause 2. Fix 3. Test command'",
+      "missing-input-boundaries": "Name the specific file and function, not just the module.",
+    };
+    const hint = flagHints[topFlag];
+    if (hint) {
+      lines.push(`\nMain growth area: ${hint}`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+function main(): void {
   const daysArg = process.argv.find((a) => a.startsWith("--days="));
-  const days = daysArg ? parseInt(daysArg.split("=")[1]) : 30;
+  const days = daysArg ? parseInt(daysArg.split("=")[1]!) : 7;
 
-  const entries = loadEntries(days);
+  const events = loadEvents(days);
 
-  if (entries.length === 0) {
+  if (events.length === 0) {
     console.log("No session data found.");
     console.log(
-      "Activate observation mode with /prompt-sensei observe to start tracking."
+      "Activate observation with `/prompt-sensei observe` to start tracking."
     );
     return;
   }
 
-  const scores = entries.map((e) => e.score);
-  const avg = scores.reduce((a, b) => a + b, 0) / scores.length;
-  const min = Math.min(...scores);
-  const max = Math.max(...scores);
-  const trend = scores.length >= 3 ? scores.slice(-3) : scores;
-  const trendAvg = trend.reduce((a, b) => a + b, 0) / trend.length;
+  const scores = events.map((e) => e.score).filter((s): s is number => s !== undefined);
+  const avgScore = avg(scores);
+  const recent3 = scores.slice(-3);
+  const older3 = scores.slice(-6, -3);
+  const trend = recent3.length > 0 && older3.length > 0
+    ? avg(recent3) - avg(older3)
+    : 0;
 
-  const gradeCounts: Record<string, number> = {
-    Master: 0,
-    Skilled: 0,
-    Developing: 0,
-    Beginner: 0,
-    "Needs work": 0,
-  };
-  for (const e of entries) {
-    const g = gradeLabel(e.score);
-    gradeCounts[g] = (gradeCounts[g] ?? 0) + 1;
-  }
+  const stageCounts = new Map<string, number>();
+  const taskCounts = new Map<string, number>();
+  const flagCounts = new Map<string, number>();
 
-  console.log("\n╔══════════════════════════════════════╗");
-  console.log("║        Prompt Sensei Report          ║");
-  console.log("╚══════════════════════════════════════╝\n");
-  console.log(`Period:   last ${days} days`);
-  console.log(`Prompts:  ${entries.length}`);
-  console.log(`Average:  ${avg.toFixed(1)}/100 — ${gradeLabel(avg)}`);
-  console.log(`Range:    ${min} – ${max}`);
-  console.log(
-    `Trend:    ${trendAvg.toFixed(1)} (last ${trend.length} prompts) ${trendAvg > avg ? "↑" : trendAvg < avg ? "↓" : "→"}`
-  );
-  console.log("\nGrade distribution:");
-
-  for (const [grade, count] of Object.entries(gradeCounts)) {
-    if (count === 0) continue;
-    const pct = ((count / entries.length) * 100).toFixed(0);
-    console.log(`  ${grade.padEnd(12)} ${bar(count, entries.length)} ${count} (${pct}%)`);
-  }
-
-  const recent = entries.slice(-5).reverse();
-  if (recent.length > 0) {
-    console.log("\nRecent prompts:");
-    for (const e of recent) {
-      const date = new Date(e.ts).toLocaleDateString();
-      const tip = e.summary ? `  ← ${e.summary}` : "";
-      console.log(`  ${date}  ${String(e.score).padStart(3)}/100  ${e.grade}${tip}`);
+  for (const event of events) {
+    if (event.stage) {
+      stageCounts.set(event.stage, (stageCounts.get(event.stage) ?? 0) + 1);
+    }
+    if (event.taskType) {
+      taskCounts.set(event.taskType, (taskCounts.get(event.taskType) ?? 0) + 1);
+    }
+    for (const flag of event.flags ?? []) {
+      flagCounts.set(flag, (flagCounts.get(flag) ?? 0) + 1);
     }
   }
 
-  console.log(
-    `\n${avg >= 75 ? "Strong work. Keep pushing for Master-level clarity." : "Focus on explicit constraints and context richness — they move scores fastest."}`
-  );
-  console.log();
+  const topStage = topN(stageCounts, 1)[0]?.[0] ?? "unknown";
+  const topTask = topN(taskCounts, 1)[0]?.[0] ?? "unknown";
+  const topFlags = topN(flagCounts, 3);
+
+  const trendSymbol = trend > 0.1 ? "↑" : trend < -0.1 ? "↓" : "→";
+
+  console.log("# Prompt Sensei Report");
+  console.log(`Observed ${events.length} prompts in the last ${days} days.\n`);
+  console.log(`**Average score:**    ${avgScore.toFixed(1)} / 5  (${gradeLabel(avgScore)})`);
+  console.log(`**Trend:**            ${trendSymbol}  ${Math.abs(trend).toFixed(1)} vs previous period`);
+  console.log(`**Most common type:** ${topTask}`);
+  console.log(`**Most common stage:** ${topStage}`);
+
+  if (scores.length >= 3) {
+    console.log(`\n**Score history:**    ${sparkline(scores.slice(-20))}`);
+  }
+
+  if (topFlags.length > 0) {
+    console.log("\n## Most common gaps");
+    for (const [flag, count] of topFlags) {
+      console.log(`- ${flag} (${count}×)`);
+    }
+  }
+
+  const stageEntries = topN(stageCounts, 5);
+  if (stageEntries.length > 0) {
+    console.log("\n## Stage breakdown");
+    for (const [stage, count] of stageEntries) {
+      const pct = ((count / events.length) * 100).toFixed(0);
+      console.log(`- ${stage}: ${count} (${pct}%)`);
+    }
+  }
+
+  console.log("\n## Feedback");
+  console.log(generateEncouragement(avgScore, trend, topStage, topFlags));
 }
 
 main();

--- a/scripts/report.ts
+++ b/scripts/report.ts
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+/**
+ * Generate a report from all local session data.
+ * Usage: npx ts-node scripts/report.ts [--days 7]
+ */
+
+import fs from "fs";
+import path from "path";
+
+const DATA_DIR = path.join(process.cwd(), ".prompt-sensei");
+
+interface PromptEntry {
+  ts: string;
+  score: number;
+  grade: string;
+  charCount?: number;
+  summary?: string;
+}
+
+function gradeLabel(score: number): string {
+  if (score >= 90) return "Master";
+  if (score >= 75) return "Skilled";
+  if (score >= 55) return "Developing";
+  if (score >= 35) return "Beginner";
+  return "Needs work";
+}
+
+function bar(value: number, max: number, width = 20): string {
+  const filled = Math.round((value / max) * width);
+  return "█".repeat(filled) + "░".repeat(width - filled);
+}
+
+function loadEntries(days: number): PromptEntry[] {
+  if (!fs.existsSync(DATA_DIR)) return [];
+
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - days);
+
+  const files = fs
+    .readdirSync(DATA_DIR)
+    .filter((f) => f.startsWith("session-") && f.endsWith(".jsonl"))
+    .sort();
+
+  const entries: PromptEntry[] = [];
+  for (const file of files) {
+    const lines = fs
+      .readFileSync(path.join(DATA_DIR, file), "utf8")
+      .split("\n")
+      .filter(Boolean);
+    for (const line of lines) {
+      try {
+        const entry = JSON.parse(line) as PromptEntry;
+        if (new Date(entry.ts) >= cutoff) {
+          entries.push(entry);
+        }
+      } catch {
+        // skip malformed lines
+      }
+    }
+  }
+  return entries;
+}
+
+function main() {
+  const daysArg = process.argv.find((a) => a.startsWith("--days="));
+  const days = daysArg ? parseInt(daysArg.split("=")[1]) : 30;
+
+  const entries = loadEntries(days);
+
+  if (entries.length === 0) {
+    console.log("No session data found.");
+    console.log(
+      "Activate observation mode with /prompt-sensei observe to start tracking."
+    );
+    return;
+  }
+
+  const scores = entries.map((e) => e.score);
+  const avg = scores.reduce((a, b) => a + b, 0) / scores.length;
+  const min = Math.min(...scores);
+  const max = Math.max(...scores);
+  const trend = scores.length >= 3 ? scores.slice(-3) : scores;
+  const trendAvg = trend.reduce((a, b) => a + b, 0) / trend.length;
+
+  const gradeCounts: Record<string, number> = {
+    Master: 0,
+    Skilled: 0,
+    Developing: 0,
+    Beginner: 0,
+    "Needs work": 0,
+  };
+  for (const e of entries) {
+    const g = gradeLabel(e.score);
+    gradeCounts[g] = (gradeCounts[g] ?? 0) + 1;
+  }
+
+  console.log("\n╔══════════════════════════════════════╗");
+  console.log("║        Prompt Sensei Report          ║");
+  console.log("╚══════════════════════════════════════╝\n");
+  console.log(`Period:   last ${days} days`);
+  console.log(`Prompts:  ${entries.length}`);
+  console.log(`Average:  ${avg.toFixed(1)}/100 — ${gradeLabel(avg)}`);
+  console.log(`Range:    ${min} – ${max}`);
+  console.log(
+    `Trend:    ${trendAvg.toFixed(1)} (last ${trend.length} prompts) ${trendAvg > avg ? "↑" : trendAvg < avg ? "↓" : "→"}`
+  );
+  console.log("\nGrade distribution:");
+
+  for (const [grade, count] of Object.entries(gradeCounts)) {
+    if (count === 0) continue;
+    const pct = ((count / entries.length) * 100).toFixed(0);
+    console.log(`  ${grade.padEnd(12)} ${bar(count, entries.length)} ${count} (${pct}%)`);
+  }
+
+  const recent = entries.slice(-5).reverse();
+  if (recent.length > 0) {
+    console.log("\nRecent prompts:");
+    for (const e of recent) {
+      const date = new Date(e.ts).toLocaleDateString();
+      const tip = e.summary ? `  ← ${e.summary}` : "";
+      console.log(`  ${date}  ${String(e.score).padStart(3)}/100  ${e.grade}${tip}`);
+    }
+  }
+
+  console.log(
+    `\n${avg >= 75 ? "Strong work. Keep pushing for Master-level clarity." : "Focus on explicit constraints and context richness — they move scores fastest."}`
+  );
+  console.log();
+}
+
+main();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": ".",
+    "resolveJsonModule": true,
+    "declaration": true
+  },
+  "include": ["scripts/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
… examples

Implements the initial structure for the prompt-sensei Claude Code skill:
- .claude/skills/prompt-sensei/SKILL.md: skill behavioral definition with 5-criteria rubric
- scripts/observe.ts, report.ts, clear.ts: local session tracking (no raw prompt storage by default)
- docs/philosophy.md, privacy.md, scoring-rubric.md: design rationale and rubric detail
- examples/debugging-journey.md: three-iteration example showing score improvement

https://claude.ai/code/session_015PdJn2CZSeozcqZsrtvg8u