### PR TITLE
v0.0.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,43 @@
+# Repository Guidance
+
+This project is a local-first prompt-coaching skill for AI coding agents. Keep changes aligned with the product principles: quiet, stage-aware, encouraging, privacy-aware, and useful for engineering workflows.
+
+## When Changing Behavior
+
+- Update `SKILL.md` when command behavior, scoring behavior, consent, storage, update checks, or report output changes.
+- Update both `README.md` and `README-zh.md` for user-facing behavior, install steps, command lists, examples, and privacy notes.
+- Update `docs/privacy.md` for any storage, deletion, or network behavior changes.
+- Update `docs/scoring-rubric.md` when stage formulas, dimensions, flags, or score labels change.
+- Update `examples/debugging-journey.md` when scoring examples, report style, or recommended prompt patterns change.
+
+## Scripts
+
+- Source files live in `scripts/*.ts`; generated files live in `dist/`.
+- Run `npm run build` after TypeScript changes.
+- Do not add network behavior except for explicit, documented update checks.
+- Do not store raw prompt text. Use metadata and redacted hashes only.
+
+## Validation
+
+Before publishing or opening a PR, run:
+
+```bash
+npm run build
+git diff --check
+```
+
+For update-related changes, also smoke test:
+
+```bash
+node dist/scripts/update.js --check --force
+node dist/scripts/report.js
+```
+
+## Release Notes
+
+PR descriptions should mention:
+
+- user-facing command changes
+- storage or privacy changes
+- report output changes
+- validation performed

--- a/README-zh.md
+++ b/README-zh.md
@@ -1,0 +1,412 @@
+# Prompt Sensei
+
+> 一个安静、本地优先、面向工程师的 AI 编程提示词教练。
+
+[English](README.md)
+
+Prompt Sensei 帮助开发者在日常使用 AI 编程工具时，逐步写出更清晰、更可执行、更适合工程协作的 prompt。
+
+它不是排行榜。
+它不是员工监控。
+它不是 prompt 警察。
+
+它是一个小型的 AI coding skill 和本地 prompt coaching 工具。它的目标不是把每个 prompt 改写得很华丽，而是帮助工程师把粗略意图变成清楚、有效、可执行的工作请求。
+
+---
+
+## 安装
+
+Claude Code:
+
+```bash
+git clone https://github.com/chengzhongwei/Prompt-sensei ~/.claude/skills/prompt-sensei
+(cd ~/.claude/skills/prompt-sensei && npm install && npm run build)
+```
+
+Claude Code 会自动读取 `~/.claude/skills/` 下的 skills。
+
+Codex:
+
+```bash
+git clone https://github.com/chengzhongwei/Prompt-sensei ~/.codex/skills/prompt-sensei
+(cd ~/.codex/skills/prompt-sensei && npm install && npm run build)
+```
+
+Codex 不使用 Claude Code 的 slash command hook 模型。可以用自然语言触发：
+
+```txt
+Use prompt-sensei to review this prompt: "fix this test"
+Use prompt-sensei to show my report.
+Use prompt-sensei observe for this session.
+```
+
+---
+
+## 使用
+
+Claude Code:
+
+```txt
+/prompt-sensei [observe|stop|report|review|help|clear|update]
+```
+
+不带参数时，默认启动观察模式：
+
+```txt
+/prompt-sensei observe          # 开始持续评分
+/prompt-sensei stop             # 停止本次会话观察
+/prompt-sensei review "help me fix this"
+/prompt-sensei report
+/prompt-sensei update
+/prompt-sensei help
+```
+
+生成报告：
+
+```bash
+npm run report
+```
+
+清理本地数据：
+
+```bash
+npm run clear-data
+```
+
+检查更新：
+
+```bash
+npm run check-update
+```
+
+应用更新：
+
+```bash
+npm run update
+```
+
+Prompt Sensei 会在 observe/report 活动中最多每天后台检查一次更新。它不会自动更新，只会提示你有新版本。需要用户主动运行 `/prompt-sensei update` 或 `npm run update`。
+
+---
+
+## 为什么需要 Prompt Sensei？
+
+AI-assisted engineering 已经变成日常工作流。但很多团队仍然会把这样的 prompt 丢给 coding agent：
+
+```txt
+fix this
+why is this broken
+make it better
+```
+
+这些 prompt 并不是“错”的。很多时候，它们只是问题早期的想法。
+
+Prompt Sensei 会根据 prompt 所处阶段给反馈：
+
+- 这是探索问题的 prompt，还是已经准备让 agent 改代码？
+- 目标是否清楚？
+- 是否给了足够上下文？
+- 是否限定了输入范围？
+- 是否给了约束？
+- 是否说明了输出格式？
+- 是否说明了如何验证？
+- 用户是否比之前更清楚了？
+
+目标不是完美 prompt。目标是更好的 AI-assisted work。
+
+---
+
+## Prompt Sensei 有什么不同？
+
+大多数 prompt 工具会直接帮你“优化”或“改写” prompt。Prompt Sensei 更像一个安静的老师。
+
+| 特性 | Prompt Sensei |
+|---|---|
+| 默认不打扰 | 不打断你的工作流 |
+| 本地优先 | 不需要云端后端 |
+| 注重隐私 | 默认不保存原始 prompt |
+| 阶段感知 | 不会惩罚早期探索型 prompt |
+| 鼓励式反馈 | 像老师，不像评分机器 |
+| 面向工程 | 适合 debugging、coding、code review、planning、docs、architecture |
+| 面向成长 | 关注习惯变化，而不是一次性分数 |
+
+Prompt Sensei 理解：
+
+```txt
+why is auth broken
+```
+
+这在探索阶段可能是完全合理的。但当你准备让 agent 真正改代码时，它会帮助你逐步走向这样的 prompt：
+
+```txt
+Please debug this failing Jest test.
+Goal:
+  Find why unauthenticated users are redirected to /dashboard instead of /login.
+Context:
+  - Stack: TypeScript, React, Jest
+  - Recent change: added refresh-token support
+  - Related files:
+    - src/middleware/auth.ts
+    - src/routes/ProtectedRoute.tsx
+    - src/__tests__/auth.test.ts
+Expected:
+  If the user has no access token and no refresh token, redirect to /login.
+Actual:
+  The test receives /dashboard.
+Constraints:
+  - Do not refactor the whole auth flow.
+  - Prefer the smallest safe fix.
+  - If the test expectation is wrong, explain why before changing it.
+Return:
+  1. Root cause
+  2. Proposed fix
+  3. Patch summary
+  4. Test command
+  5. Edge cases to verify
+```
+
+这就是模糊请求和可执行工程请求之间的差别。
+
+---
+
+## Prompt 阶段
+
+Prompt Sensei 不会用同一把尺子衡量所有 prompt。
+
+| 阶段 | 含义 | 示例 |
+|---|---|---|
+| Exploration | 还在理解问题 | `why is this broken` |
+| Diagnosis | 已经有症状或证据 | `expected /login, actual /dashboard` |
+| Execution | 希望 agent 实现或修改 | `implement this with these constraints` |
+| Verification | 希望检查正确性 | `find edge cases and test commands` |
+| Reusable workflow | 希望得到可复用流程 | `create a code review checklist` |
+| Action | 已有上下文里的短指令 | `ok commit and push to main`, `run the tests` |
+
+一个模糊 prompt 在探索阶段可能没问题，但在执行阶段通常不够。Action prompt 不会因为缺少 Constraints、Verification、Output Format 被扣分，因为这些维度不适用于短 follow-through 指令。
+
+---
+
+## 评分维度
+
+Prompt Sensei 使用七个工程实用维度评分：
+
+| 维度 | 检查什么 |
+|---|---|
+| Goal clarity | 目标是否清楚 |
+| Context completeness | 背景是否足够 |
+| Input boundaries | 输入范围是否明确 |
+| Constraints | 是否有范围、依赖、风格、安全约束 |
+| Output format | 是否说明希望回答如何组织 |
+| Verification | 是否说明如何验证正确性 |
+| Privacy/safety | 是否避免不必要的敏感信息 |
+
+分数用于私人的反馈和趋势跟踪，不用于排名。
+
+---
+
+## 为什么分数可能会下降？
+
+Prompt Sensei 的分数是 stage-aware 的。它不是每次都问：“这个 prompt 是否是完美的执行型 prompt？”它会先问：“这个 prompt 现在处于什么阶段？”
+
+例如：
+
+```txt
+why is auth broken
+```
+
+作为 Exploration，它可能得分不错，因为早期只需要一个清楚方向，并且不泄露敏感信息。
+
+但当你开始要求 agent 改文件时，同样的信息量在 Execution 阶段可能会得分更低，因为此时需要更多维度：上下文、输入范围、约束、输出格式、验证方式。
+
+所以当 prompt 从 Exploration 进入 Execution，分数下降不一定是退步。它只是说明：现在 agent 可能会修改真实文件，因此 Prompt Sensei 提高了标准。
+
+---
+
+## Demo
+
+**初始 prompt**
+
+```txt
+fix this test
+```
+
+**Prompt Sensei feedback**
+
+```txt
+Prompt stage:    Exploration
+Score:           70 / 100  (Good for Exploration)
+
+What is good:
+  You clearly indicated you need debugging help.
+
+What is missing for execution:
+  - failing test output
+  - expected behavior
+  - actual behavior
+  - related files
+  - verification command
+
+Suggested rewrite:
+  Please debug this failing Jest test.
+  Context:
+    - Stack: TypeScript, React, Jest
+    - Related file: src/__tests__/auth.test.ts
+    - Expected: unauthenticated users redirect to /login
+    - Actual: test redirects to /dashboard
+  Return:
+    1. Root cause
+    2. Minimal fix
+    3. Test command
+    4. Edge cases to verify
+
+Habit to practice next:
+  Add expected behavior and actual behavior to every debugging prompt.
+```
+
+---
+
+## 观察模式
+
+启动观察模式：
+
+```txt
+/prompt-sensei observe
+```
+
+`/prompt-sensei` 不带参数时等价于 `/prompt-sensei observe`。
+
+之后每次回复末尾会追加一行：
+
+> **[Sensei: Score - 68/100; Tip: add the error message and file path]**
+
+如果 prompt 很成熟：
+
+> **[Sensei: Score - 94/100; Excellent — execution-ready prompt]**
+
+评分等级：
+
+| 分数 | 等级 | 含义 |
+|---|---|---|
+| 90–100 | Excellent | execution-ready |
+| 70–89 | Good | 小问题 |
+| 50–69 | Developing | 有明显改进空间 |
+| 30–49 | Early stage | 探索阶段很常见 |
+| 10–29 | Needs work | 先从目标清晰度开始 |
+
+---
+
+## Good Prompt Pattern
+
+执行型 prompt 通常可以用这个结构：
+
+```txt
+Goal:         What do you want?
+Context:      What should the AI know?
+Input:        What should the AI use?
+Constraints:  What should the AI avoid or prioritize?
+Output:       How should the answer be structured?
+Verification: How should correctness be checked?
+```
+
+不是每个 prompt 都需要六项。根据阶段来决定深度。
+
+---
+
+## 隐私模型
+
+Prompt Sensei 默认本地优先：
+
+- 没有云端后端
+- 没有 telemetry
+- 没有登录
+- 没有排行榜
+- 默认不保存原始 prompt
+
+观察模式默认只保存：
+
+- timestamp
+- prompt stage
+- task type
+- score
+- feedback flags
+- 可选的 redacted prompt hash
+
+本地文件：
+
+- `~/.prompt-sensei/events.jsonl` — 观察日志
+- `~/.prompt-sensei/config.json` — consent 记录
+- `~/.prompt-sensei/update-check.json` — 更新检查缓存
+
+详见 [docs/privacy.md](docs/privacy.md)。
+
+---
+
+## 示例报告
+
+```txt
+# Prompt Sensei Report
+Observed 18 prompts in the last 7 days.
+
+**Average score:**     68 / 100  (Developing)
+**Trend:**             ↑  6 pts vs previous 5 prompts
+**Most common type:**  debugging
+**Most common stage:** diagnosis
+**Stage trend:**       more execution prompts recently (3/5 vs 1/5 previous)
+
+**Score history:**     ▂▃▃▄▄▄▅▅▆▆
+
+## Most common gaps
+- missing-context (7×)
+- no-verification (5×)
+- no-constraints (3×)
+
+## Growth area by task type
+- debugging: missing-context (5×)
+- implementation: no-verification (3×)
+
+## Stage breakdown
+- diagnosis: 9 (50%)
+- execution: 6 (33%)
+- exploration: 3 (17%)
+
+## Feedback
+Your scores are trending upward. The practice is working.
+Your debugging prompts are in the developing range. The next gain is likely one missing detail, not a full rewrite.
+
+Next habit for debugging: Add the error message, expected behavior, and recent change before asking for help.
+Why it matters: Context is the difference between guessing and diagnosing.
+Practice: For the next three debugging prompts, include Expected, Actual, and Recent change.
+```
+
+---
+
+## 适合谁？
+
+Prompt Sensei 适合：
+
+- 使用 Claude Code、Codex 或类似 AI coding agent 的工程师
+- 正在引入 AI coding workflow 的团队
+- 希望提升 AI 协作效率的开发者
+- 希望通过实践学习 prompt engineering 的人
+
+尤其适合 debugging、implementation、code review、refactoring、architecture、planning、documentation、testing 等场景。
+
+---
+
+## 它不是什么？
+
+Prompt Sensei 不是：
+
+- prompt marketplace
+- 营销文案优化器
+- 生产级 LLM eval 平台
+- 员工监控工具
+- 工程判断的替代品
+
+它只是一个小型、本地、安静的 prompt mentor，帮助你养成更好的 AI 编程习惯。
+
+---
+
+## License
+
+Apache-2.0 — Copyright 2026 Chengzhong Wei

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Claude Code picks up skills in `~/.claude/skills/` automatically.
 ### Use as a Claude Code skill
 
 ```
-/prompt-sensei [observe|stop|report|review|help|clear]
+/prompt-sensei [observe|stop|report|review|help|clear|update]
 ```
 
 With no arguments, starts observation mode by default — scores your prompts quietly as you work.
@@ -34,6 +34,7 @@ With no arguments, starts observation mode by default — scores your prompts qu
 /prompt-sensei stop             # stop scoring this session
 /prompt-sensei review "help me fix this"
 /prompt-sensei report
+/prompt-sensei update
 /prompt-sensei help
 ```
 
@@ -88,6 +89,20 @@ Clear local data:
 ```bash
 npm run clear-data
 ```
+
+Check for updates:
+
+```bash
+npm run check-update
+```
+
+Apply updates:
+
+```bash
+npm run update
+```
+
+Prompt Sensei checks for updates in the background at most once per day during observe/report activity. It never auto-updates; it only tells you when a newer commit is available. Run `/prompt-sensei update` or `npm run update` to pull the latest version and rebuild.
 
 ---
 
@@ -348,6 +363,12 @@ To see your session statistics:
 /prompt-sensei report
 ```
 
+To update Prompt Sensei:
+
+```
+/prompt-sensei update
+```
+
 To clear local data:
 
 ```
@@ -432,6 +453,12 @@ Observed 18 prompts in the last 7 days.
 - diagnosis: 9 (50%)
 - execution: 6 (33%)
 - exploration: 3 (17%)
+
+## Update
+Update available on `main`.
+- Local: 65fb4ad
+- Remote: 31e4a5b
+- Run `/prompt-sensei update` to update.
 
 ## Feedback
 Your scores are trending upward. The practice is working.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 > A quiet, local-first prompt mentor for engineers using AI coding tools.
 
+[中文说明](README-zh.md)
+
 Prompt Sensei helps developers improve their AI prompts over time with gentle, stage-aware feedback.
 
 It is not a leaderboard.
@@ -231,13 +233,12 @@ fix this test
 
 ```
 Prompt stage:    Exploration
-Score:           2.0 / 5  (as execution-ready)
-                 3.5 / 5  (as exploration)
+Score:           70 / 100  (Good for Exploration)
 
 What is good:
   You clearly indicated you need debugging help.
 
-What is missing:
+What is missing for execution:
   - failing test output
   - expected behavior
   - actual behavior

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It is not a leaderboard.
 It is not employee surveillance.
 It is not prompt police.
 
-It is a small Claude Code skill and local prompt-coaching toolkit that helps engineers turn rough intent into clear, effective, work-ready prompts.
+It is a small AI coding skill and local prompt-coaching toolkit that helps engineers turn rough intent into clear, effective, work-ready prompts.
 
 ---
 
@@ -37,6 +37,25 @@ With no arguments, starts observation mode by default — scores your prompts qu
 /prompt-sensei help
 ```
 
+### Use as a Codex skill
+
+Install the same project into Codex's skills directory:
+
+```bash
+git clone https://github.com/chengzhongwei/Prompt-sensei ~/.codex/skills/prompt-sensei
+(cd ~/.codex/skills/prompt-sensei && npm install && npm run build)
+```
+
+Codex does not use the Claude Code slash-command hook model. Use natural language instead:
+
+```txt
+Use prompt-sensei to review this prompt: "fix this test"
+Use prompt-sensei to show my report.
+Use prompt-sensei observe for this session.
+```
+
+Codex can use the same rubric and local report scripts. Automatic per-message observation depends on the host app keeping the skill active in context; the Claude Code hook shown below is Claude-specific.
+
 ### Optional: Enable local prompt observation
 
 Add to your Claude Code settings (`~/.claude/settings.json`):
@@ -47,7 +66,7 @@ Add to your Claude Code settings (`~/.claude/settings.json`):
     "UserPromptSubmit": [
       {
         "type": "command",
-        "command": "node ~/.claude/skills/prompt-sensei/dist/scripts/observe.js",
+        "command": "node ~/.claude/skills/prompt-sensei/dist/scripts/observe.js --hash-only",
         "async": true,
         "timeout": 10
       }
@@ -56,7 +75,7 @@ Add to your Claude Code settings (`~/.claude/settings.json`):
 }
 ```
 
-The observer writes local metadata to `~/.prompt-sensei/events.jsonl`.
+The hook writes only a redacted prompt hash to `~/.prompt-sensei/events.jsonl`, and only after you have consented by running `/prompt-sensei observe` once. Hash-only hook captures are excluded from scoring because the hook does not have the conversation context needed for stage-aware feedback.
 
 Generate a report:
 
@@ -256,20 +275,26 @@ Prompt Sensei does not just ask "Was this prompt good?" It asks "Is the user lea
 
 ### 1. Claude Code Skill
 
-Use it on demand:
+Start observation mode with no arguments:
 
 ```
 /prompt-sensei
 ```
 
-or:
+This is the same as:
+
+```
+/prompt-sensei observe
+```
+
+Use review mode when you want feedback on one specific prompt without starting ongoing observation:
 
 ```
 /prompt-sensei review this prompt:
 "fix this test"
 ```
 
-The skill gives feedback on prompt stage, task type, clarity, context, constraints, output format, verification, privacy/safety, a suggested rewrite, and one habit to practice next.
+Review mode gives feedback on prompt stage, task type, clarity, context, constraints, output format, verification, privacy/safety, a suggested rewrite, and one habit to practice next.
 
 ### 2. Observe Mode — Inline Scoring
 
@@ -279,13 +304,15 @@ Activate observation mode to get a live score after every prompt you send:
 /prompt-sensei observe
 ```
 
+`/prompt-sensei` with no arguments also starts observation mode.
+
 After each message, Prompt Sensei appends a one-line score at the end of its response:
 
-> **[[Sensei: Score - 68/100; Tip: add the error message and file path]]()**
+> **[Sensei: Score - 68/100; Tip: add the error message and file path]**
 
 When your prompt is excellent:
 
-> **[[Sensei: Score - 94/100; Excellent — execution-ready prompt]]()**
+> **[Sensei: Score - 94/100; Excellent — execution-ready prompt]**
 
 The score is calculated from 7 dimensions on a 1–5 scale, converted to /100. The tip always names the single most impactful improvement — one habit at a time, not a list.
 
@@ -300,6 +327,14 @@ Scores by stage:
 | 10–29 | Needs work | Start with goal clarity |
 
 Action prompts (short follow-through directives) are only scored on Goal Clarity and Privacy/Safety — never penalized for missing Constraints, Verification, or Output Format.
+
+### Why stage-aware scores can move down
+
+Prompt Sensei does not ask "is this a perfect execution prompt?" at every stage. It first asks "what kind of prompt is this?"
+
+An early debugging prompt like `why is auth broken` may score well as Exploration because it only needs a clear direction and no sensitive data. Later, once you ask the agent to edit files, the same level of detail would score lower as Execution because more dimensions apply: context, input boundaries, constraints, output format, and verification.
+
+So a score can dip when a prompt moves from Exploration to Execution. That is not a regression. It means the prompt has entered a stage where the agent can make real changes, so Prompt Sensei raises the bar.
 
 To stop observation for the current session:
 
@@ -319,21 +354,18 @@ To clear local data:
 /prompt-sensei clear
 ```
 
-### 3. Optional Local Observer
+### 3. Optional Local Hook
 
-Prompt Sensei can optionally observe Claude Code prompts through a local hook, recording metadata silently in the background without needing the skill to be active.
+Prompt Sensei can optionally hash Claude Code prompts through a local hook, recording lightweight metadata silently in the background after consent.
 
-The observer:
+The hook:
 
 - reads prompt events locally
 - redacts sensitive data (emails, API keys, tokens)
 - hashes prompts
-- classifies prompt stage
-- scores prompt quality
-- stores lightweight metadata locally
-- generates private reports
+- stores the hash locally as a hash-only capture
 
-By default, it does not store raw prompts.
+It does not classify or score prompts. Stage-aware scoring happens only in `/prompt-sensei observe`, where Claude has enough session context to classify the prompt and append feedback.
 
 ---
 
@@ -363,19 +395,11 @@ Prompt Sensei is privacy-first by design.
 - no leaderboard
 - no raw prompt storage
 
-By default, Prompt Sensei stores only: timestamp, task type, prompt stage, prompt hash, scores, and lightweight feedback tags.
+By default, Prompt Sensei stores only: timestamp, task type, prompt stage, prompt hash, scores, and lightweight feedback tags. Hook mode stores only timestamp and prompt hash.
 
 Two files are created locally on first use:
 - `~/.prompt-sensei/events.jsonl` — observation log
 - `~/.prompt-sensei/config.json` — consent record (created once)
-
-Raw prompt storage is opt-in only:
-
-```bash
-PROMPT_SENSEI_STORE_RAW=1 npm run observe
-```
-
-Even then, Prompt Sensei attempts to redact emails, API keys, tokens, private keys, and URLs with query parameters before storing.
 
 See [docs/privacy.md](docs/privacy.md) for full details.
 
@@ -391,6 +415,7 @@ Observed 18 prompts in the last 7 days.
 **Trend:**             ↑  6 pts vs previous 5 prompts
 **Most common type:**  debugging
 **Most common stage:** diagnosis
+**Stage trend:**       more execution prompts recently (3/5 vs 1/5 previous)
 
 **Score history:**     ▂▃▃▄▄▄▅▅▆▆
 
@@ -399,6 +424,10 @@ Observed 18 prompts in the last 7 days.
 - no-verification (5×)
 - no-constraints (3×)
 
+## Growth area by task type
+- debugging: missing-context (5×)
+- implementation: no-verification (3×)
+
 ## Stage breakdown
 - diagnosis: 9 (50%)
 - execution: 6 (33%)
@@ -406,9 +435,11 @@ Observed 18 prompts in the last 7 days.
 
 ## Feedback
 Your scores are trending upward. The practice is working.
-You are in the developing stage. The gap between where you are and 'good' is smaller than it feels.
+Your debugging prompts are in the developing range. The next gain is likely one missing detail, not a full rewrite.
 
-Main growth area: Try adding the error message or stack trace to every debugging prompt.
+Next habit for debugging: Add the error message, expected behavior, and recent change before asking for help.
+Why it matters: Context is the difference between guessing and diagnosing.
+Practice: For the next three debugging prompts, include Expected, Actual, and Recent change.
 ```
 
 ---
@@ -417,7 +448,7 @@ Main growth area: Try adding the error message or stack trace to every debugging
 
 Prompt Sensei is for:
 
-- engineers using Claude Code
+- engineers using Claude Code, Codex, or similar AI coding agents
 - teams adopting AI coding tools
 - developers who want better AI results
 - people learning prompt engineering through practice

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,10 +1,12 @@
 ---
+name: prompt-sensei
+description: Use when the user wants stage-aware prompt coaching, prompt scoring, prompt review, prompting habit feedback, or local reports about prompt quality for AI coding agents such as Claude Code or Codex.
 argument-hint: [observe|stop|report|review|help|clear]
 ---
 
 # Prompt Sensei
 
-You are Prompt Sensei — a quiet, encouraging prompt mentor for engineers using Claude Code. Your job is to give stage-aware, specific feedback that helps developers improve one habit at a time.
+You are Prompt Sensei — a quiet, encouraging prompt mentor for engineers using AI coding agents such as Claude Code and Codex. Your job is to give stage-aware, specific feedback that helps developers improve one habit at a time.
 
 You are not a judge. You are a teacher.
 
@@ -19,6 +21,13 @@ This skill is triggered by `/prompt-sensei`. Read the arguments the user provide
 - `/prompt-sensei review <prompt>` or `/prompt-sensei score <prompt>` — score a specific prompt and give feedback
 - `/prompt-sensei report` — run the report script and display session statistics
 - `/prompt-sensei clear` — run the clear script to delete session data
+
+In Codex or other environments without slash-command support, treat natural-language requests such as "use prompt-sensei", "score this prompt", "review my prompt", or "show my prompt-sensei report" as equivalent invocations.
+
+When running bundled scripts, use the installed skill root:
+- Claude Code default: `~/.claude/skills/prompt-sensei`
+- Codex default: `~/.codex/skills/prompt-sensei`
+- If the current working directory is the skill root, prefer `node dist/scripts/<script>.js`
 
 ---
 
@@ -35,13 +44,13 @@ Before scoring any prompt, classify it into one of these stages. This is the mos
 | **Reusable workflow** | User wants a repeatable process | asks for a checklist, template, or process |
 | **Action** | Short follow-through directive in an established session | ≤8 words, refers entirely to prior context, no new requirements introduced — e.g. "ok commit and push to main", "run the tests", "revert that" |
 
-Stage-aware scoring principle: **do not penalize exploration or action prompts for missing execution details.** A prompt classified as Exploration or Action is scored on Goal Clarity and Privacy/Safety only. Never penalize Action prompts for missing Constraints, Verification, or Output Format — those are not expected in a follow-through directive. An Execution prompt is scored on all seven dimensions.
+Stage-aware scoring principle: **do not penalize exploration or action prompts for missing execution details.** A prompt classified as Exploration or Action is scored on Goal Clarity and Privacy/Safety only. Never penalize Action prompts for missing Constraints, Verification, or Output Format — those are not expected in a follow-through directive. Use the composite score table below as the source of truth for which dimensions apply to each stage.
 
 ---
 
 ## Scoring Dimensions
 
-Score each dimension from 1 to 5. Apply all seven for Execution and Verification prompts. For Exploration and Diagnosis, weight Goal Clarity, Context Completeness, and Privacy/Safety most heavily.
+Score each applicable dimension from 1 to 5. Do not score dimensions that are excluded by the composite score table.
 
 ### 1. Goal Clarity (all stages)
 Is the desired outcome clear?
@@ -74,7 +83,7 @@ Is it clear what Claude should read, use, or focus on?
 - 4: File named.
 - 5: File + function or line range named.
 
-### 4. Constraints (Execution)
+### 4. Constraints (Execution, Reusable workflow)
 Are scope limits and tradeoffs stated?
 - 1: No constraints.
 - 2: One vague constraint ("keep it simple").
@@ -90,7 +99,7 @@ Did the user specify how the response should be structured?
 - 4: Format specified ("return: root cause, fix, test command").
 - 5: Format fully specified with numbered list, structure, or example.
 
-### 6. Verification (Execution, Verification)
+### 6. Verification (Execution, Verification, Reusable workflow)
 Did the user ask how to check correctness?
 - 1: No mention of verification.
 - 2: "Make sure it works" (no method).
@@ -110,11 +119,16 @@ Did the prompt avoid unnecessary sensitive data?
 
 ## Composite Score Formula
 
-**Exploration:** Average of Goal Clarity + Privacy/Safety (2 dimensions)
-**Action:** Average of Goal Clarity + Privacy/Safety (2 dimensions)
-**Diagnosis:** Average of Goal Clarity + Context Completeness + Privacy/Safety (3 dimensions)
-**Execution:** Average of all 7 dimensions
-**Verification:** Average of Goal Clarity + Context Completeness + Input Boundaries + Output Format + Verification + Privacy/Safety (6 dimensions)
+| Stage | Dimensions included in composite |
+|---|---|
+| **Exploration** | Goal Clarity + Privacy/Safety |
+| **Diagnosis** | Goal Clarity + Context Completeness + Privacy/Safety |
+| **Execution** | All seven dimensions |
+| **Verification** | Goal Clarity + Context Completeness + Input Boundaries + Output Format + Verification + Privacy/Safety |
+| **Reusable workflow** | Goal Clarity + Context Completeness + Input Boundaries + Constraints + Output Format + Verification + Privacy/Safety |
+| **Action** | Goal Clarity + Privacy/Safety |
+
+Verification-stage prompts exclude Constraints because the user is asking for correctness checks, not a change plan. Reusable workflow prompts include Constraints because good repeatable processes need scope, audience, and adoption boundaries.
 
 Individual dimensions are scored 1–5. The composite is reported as XX / 100 (average of applicable dimensions × 20, rounded to nearest integer). A prompt with no issues scores 100 / 100.
 
@@ -151,13 +165,13 @@ When the user activates `/prompt-sensei observe`:
      Ready to begin? (yes / no)
      ```
    - Wait for the user to confirm before activating. If they say no, exit gracefully.
-   - On confirmation, run: `node ~/.claude/skills/prompt-sensei/dist/scripts/observe.js --init`
+   - On confirmation, run the observe init script from the installed skill root, for example `node ~/.claude/skills/prompt-sensei/dist/scripts/observe.js --init` or `node ~/.codex/skills/prompt-sensei/dist/scripts/observe.js --init`.
 
 3. After each subsequent user message this session:
    - Classify the prompt stage
    - Score it on the relevant dimensions
    - Convert the composite score (1–5) to a 100-point display score by multiplying by 20 and rounding to the nearest integer
-   - Run: `node ~/.claude/skills/prompt-sensei/dist/scripts/observe.js --stage <stage> --score <1-5-composite-score> --task-type <type> --flags <comma-separated-flags>`
+   - Run the observe script from the installed skill root with: `node dist/scripts/observe.js --stage <stage> --score <1-5-composite-score> --task-type <type> --flags <comma-separated-flags>`
    - Valid flags (include all that apply, omit the rest). **Omit `--flags` entirely for Action-stage prompts.**
      - `missing-context` — context completeness scored low
      - `no-constraints` — no constraints were stated
@@ -234,7 +248,7 @@ Suggested rewrite:
 Run the report script:
 
 ```bash
-node ~/.claude/skills/prompt-sensei/dist/scripts/report.js
+node dist/scripts/report.js
 ```
 
 Display the output verbatim — it is already formatted as Markdown.
@@ -248,7 +262,7 @@ If no session data exists, say: "No session data found. Activate observation wit
 Run the clear script:
 
 ```bash
-node ~/.claude/skills/prompt-sensei/dist/scripts/clear.js
+node dist/scripts/clear.js
 ```
 
 Confirm what was deleted and how many entries were removed.
@@ -260,7 +274,7 @@ Confirm what was deleted and how many entries were removed.
 Display:
 
 ```
-Prompt Sensei — a quiet prompt mentor for Claude Code
+Prompt Sensei — a quiet prompt mentor for AI coding agents
 
 Commands:
   /prompt-sensei observe               Score prompts as you write them

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: prompt-sensei
 description: Use when the user wants stage-aware prompt coaching, prompt scoring, prompt review, prompting habit feedback, or local reports about prompt quality for AI coding agents such as Claude Code or Codex.
-argument-hint: [observe|stop|report|review|help|clear]
+argument-hint: [observe|stop|report|review|help|clear|update]
 ---
 
 # Prompt Sensei
@@ -21,6 +21,7 @@ This skill is triggered by `/prompt-sensei`. Read the arguments the user provide
 - `/prompt-sensei review <prompt>` or `/prompt-sensei score <prompt>` — score a specific prompt and give feedback
 - `/prompt-sensei report` — run the report script and display session statistics
 - `/prompt-sensei clear` — run the clear script to delete session data
+- `/prompt-sensei update` — run the update script to pull the latest version and rebuild
 
 In Codex or other environments without slash-command support, treat natural-language requests such as "use prompt-sensei", "score this prompt", "review my prompt", or "show my prompt-sensei report" as equivalent invocations.
 
@@ -156,10 +157,12 @@ When the user activates `/prompt-sensei observe`:
        - A hash of your prompt (not the text itself)
        - Dimension scores
        - Lightweight feedback tags
+       - Cached update-check status
 
      I store nothing in the cloud. Raw prompt text is never saved by default.
      Data goes to: ~/.prompt-sensei/events.jsonl  (observation log)
                    ~/.prompt-sensei/config.json    (consent record, created once)
+                   ~/.prompt-sensei/update-check.json (cached update status)
      You can inspect or delete it anytime with /prompt-sensei clear
 
      Ready to begin? (yes / no)
@@ -189,6 +192,22 @@ When the user activates `/prompt-sensei observe`:
    ```
    > **[[Sensei: Score - 94/100; Excellent — execution-ready prompt]]()**
    ```
+
+---
+
+## Behavior in Update Mode
+
+When the user types `/prompt-sensei update`:
+
+1. Run the update script from the installed skill root:
+
+```bash
+node dist/scripts/update.js --apply
+```
+
+2. Display the script output. If the working tree has local changes, tell the user to commit, stash, or discard them before updating.
+
+Prompt Sensei also performs a best-effort background update check at most once per day during observe/report activity. It never auto-updates. If an update is available, reports should tell the user to run `/prompt-sensei update`.
 
 ---
 
@@ -281,6 +300,7 @@ Commands:
   /prompt-sensei stop                  Stop scoring for this session
   /prompt-sensei review "<prompt>"     Score and improve a specific prompt
   /prompt-sensei report                Show your session statistics
+  /prompt-sensei update                Pull the latest version and rebuild
   /prompt-sensei clear                 Delete local session data
   /prompt-sensei help                  Show this help
 

--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -16,7 +16,7 @@ It says: **This was reasonable as an exploration prompt. Now that you know the f
 
 Prompting for a chat model is forgiving. If your question is vague, the model gives a vague answer and you try again. The cost is low.
 
-Prompting for an agentic coding tool like Claude Code is different. The agent edits real files, makes real changes, and can produce results that are hard to reverse. A vague prompt does not just produce a vague answer — it produces undiscussed decisions, over-broad edits, and revision loops that waste time.
+Prompting for an agentic coding tool like Claude Code or Codex is different. The agent edits real files, makes real changes, and can produce results that are hard to reverse. A vague prompt does not just produce a vague answer — it produces undiscussed decisions, over-broad edits, and revision loops that waste time.
 
 Prompt quality in this context is a professional skill, not a nicety.
 
@@ -28,7 +28,9 @@ The most important design principle in Prompt Sensei is that **stage matters mor
 
 A one-line exploration prompt like `why is auth broken` is not a failed execution prompt. It is the right prompt for the moment — you are still gathering evidence. Penalizing it like an execution request is wrong and discouraging.
 
-Prompt Sensei classifies every prompt before scoring it. An exploration prompt is scored lightly — primarily on goal clarity and privacy. An execution prompt is scored on all seven dimensions. The same feedback that helps an execution prompt would confuse someone still in exploration.
+Prompt Sensei classifies every prompt before scoring it. An exploration prompt is scored lightly — primarily on goal clarity and privacy. An execution prompt is scored on all seven dimensions. Verification and reusable workflow prompts use their own dimension sets. The same feedback that helps an execution prompt would confuse someone still in exploration.
+
+Because the rubric is stage-aware, scores are not meant to be compared blindly across stages. Moving from Exploration to Execution can lower the displayed score because more dimensions suddenly apply. That is not a regression. It means the prompt is now being judged by the standard of the work it is asking Claude to do.
 
 This is the key insight the rubric is built around.
 
@@ -56,17 +58,19 @@ This is slow enough to internalize and fast enough to try immediately.
 
 ## Growth over perfection
 
-Prompt Sensei tracks trends, not one-off scores. A prompt that scores 2.5 is not a failure — it is a baseline. If the next similar prompt scores 3.2, that is progress worth noting.
+Prompt Sensei tracks trends, not one-off scores. A prompt that scores 50/100 is not a failure — it is a baseline. If the next similar prompt scores 64/100, that is progress worth noting.
 
-The reports are designed to show movement, not rank. The goal is "Is the user learning?" not "Is this prompt good?"
+The reports are designed to show movement, not rank. They separate scored observations from hash-only hook captures, and the most useful signal is the next habit to practice for the task type the user actually does. The goal is "Is the user learning?" not "Is this prompt good?"
 
 ---
 
 ## Privacy as a first principle
 
-Prompt content is sensitive. It often contains business logic, debugging context, internal file paths, or in-progress thinking. Storing it without consent is not acceptable.
+Prompt content is sensitive. It often contains business logic, debugging context, internal file paths, or in-progress thinking. Storing even lightweight metadata without consent is not acceptable.
 
-Prompt Sensei stores nothing by default except scores and metadata. No raw text. No cloud. No accounts. The consent check at first use is not a legal formality — it is a moment to give users control before data collection starts.
+Prompt Sensei stores nothing until the user consents. After consent, observe mode stores scored metadata: timestamp, stage, task type, score, feedback flags, and optionally a redacted prompt hash when prompt text is available to the local script. It does not store raw prompt text or conversation history. The optional hook records hash-only captures after consent; those captures are excluded from score trends because they do not contain stage or score data.
+
+No cloud. No accounts. No raw conversation archive. The consent check at first use is not a legal formality — it is a moment to give users control before data collection starts.
 
 The data that is stored is auditable: it is human-readable JSON in a file on your machine. You can inspect it, understand it, and delete it in seconds.
 

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -20,6 +20,14 @@ When observation mode is active, Prompt Sensei records the following per prompt:
 
 **Raw prompt text is never stored by default.**
 
+When the optional Claude Code hook is enabled, it records hash-only captures after consent:
+
+| Field | Type | Example |
+|---|---|---|
+| `ts` | string | `"2026-04-25T14:32:10Z"` |
+| `type` | string | `"prompt-hashed"` |
+| `promptHash` | string | `"a3f1b2c4..."` |
+
 ---
 
 ## What is never stored
@@ -54,15 +62,9 @@ Consent is stored in `~/.prompt-sensei/config.json`. The prompt only appears onc
 
 ---
 
-## Opting in to raw prompt storage
+## Hashing and redaction
 
-If you want to store your prompt text locally for your own analysis, run:
-
-```bash
-PROMPT_SENSEI_STORE_RAW=1 npm run observe
-```
-
-Even in raw storage mode, Prompt Sensei attempts to redact:
+Prompt Sensei does not support raw prompt storage. When prompt text is available through stdin, it is redacted before hashing. Redaction covers:
 
 - Email addresses
 - API keys and tokens (detected by common prefixes: `sk-`, `ghp_`, `xox*`, etc.)
@@ -72,7 +74,7 @@ Even in raw storage mode, Prompt Sensei attempts to redact:
 
 Redacted fields are replaced with labeled placeholders: `[EMAIL]`, `[API_KEY]`, `[CREDENTIAL]`, etc.
 
-Raw storage is opt-in, local-only, and redacted. Nothing is sent externally.
+Only the hash prefix is stored. Nothing is sent externally.
 
 ---
 
@@ -90,7 +92,7 @@ Each line is a readable JSON object. There is no binary format, no encryption, n
 
 ## Deleting your data
 
-From Claude Code:
+From Prompt Sensei:
 
 ```
 /prompt-sensei clear
@@ -124,9 +126,8 @@ Prompt Sensei contains no analytics, no error reporting, no usage tracking, and 
 
 If you are working in an environment with strict data handling requirements:
 
-1. Keep `PROMPT_SENSEI_STORE_RAW` unset (the default — no raw text stored)
-2. Add `~/.prompt-sensei/` to your backup exclusion rules if applicable
-3. Run `clear` at the end of each session if required by policy
-4. Review `scripts/observe.ts` to audit data collection before enabling the hook
+1. Add `~/.prompt-sensei/` to your backup exclusion rules if applicable
+2. Run `clear` at the end of each session if required by policy
+3. Review `scripts/observe.ts` to audit data collection before enabling the hook
 
 Prompt Sensei is designed to be safe to use in sensitive contexts with default settings.

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -28,6 +28,16 @@ When the optional Claude Code hook is enabled, it records hash-only captures aft
 | `type` | string | `"prompt-hashed"` |
 | `promptHash` | string | `"a3f1b2c4..."` |
 
+Prompt Sensei also stores cached update-check status when update checks run:
+
+| Field | Type | Example |
+|---|---|---|
+| `checkedAt` | string | `"2026-04-25T14:32:10Z"` |
+| `status` | string | `"update-available"` |
+| `branch` | string | `"main"` |
+| `currentSha` | string | `"65fb4ad..."` |
+| `remoteSha` | string | `"31e4a5b..."` |
+
 ---
 
 ## What is never stored
@@ -116,9 +126,13 @@ node dist/scripts/clear.js --all
 
 ---
 
-## No network calls
+## Network behavior
 
-Prompt Sensei contains no analytics, no error reporting, no usage tracking, and no network calls of any kind. The scripts are local Node.js executables. You can verify this by reading the source in `scripts/` — there are no HTTP clients, no `fetch` calls, and no third-party SDKs.
+Prompt Sensei contains no analytics, no error reporting, and no usage tracking. It makes no network calls for prompt observation or reporting.
+
+The only networked feature is update checking. At most once per day during observe/report activity, Prompt Sensei may run `git ls-remote` against the configured `origin` remote to compare the local commit with the remote branch. It stores only update status and commit SHAs in `~/.prompt-sensei/update-check.json`. It never sends prompt text, scores, reports, or local event data.
+
+Updates are never applied automatically. `/prompt-sensei update` runs `git pull --ff-only`, `npm install`, and `npm run build` only when the user explicitly requests it.
 
 ---
 

--- a/docs/scoring-rubric.md
+++ b/docs/scoring-rubric.md
@@ -21,15 +21,15 @@ Action prompts are never penalized for missing Constraints, Verification, or Out
 
 **Dimensions scored per stage:**
 
-| Dimension | Exploration | Diagnosis | Execution | Verification | Action |
-|---|---|---|---|---|---|
-| Goal Clarity | ✓ | ✓ | ✓ | ✓ | ✓ |
-| Context Completeness | | ✓ | ✓ | ✓ | |
-| Input Boundaries | | | ✓ | ✓ | |
-| Constraints | | | ✓ | | |
-| Output Format | | | ✓ | ✓ | |
-| Verification | | | ✓ | ✓ | |
-| Privacy/Safety | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Dimension | Exploration | Diagnosis | Execution | Verification | Reusable workflow | Action |
+|---|---|---|---|---|---|---|
+| Goal Clarity | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Context Completeness | | ✓ | ✓ | ✓ | ✓ | |
+| Input Boundaries | | | ✓ | ✓ | ✓ | |
+| Constraints | | | ✓ | | ✓ | |
+| Output Format | | | ✓ | ✓ | ✓ | |
+| Verification | | | ✓ | ✓ | ✓ | |
+| Privacy/Safety | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 
 ---
 
@@ -86,7 +86,7 @@ Is it clear what Claude should read, use, or focus on?
 
 ---
 
-### 4. Constraints (Execution)
+### 4. Constraints (Execution, Reusable workflow)
 
 Are scope limits and tradeoffs stated?
 
@@ -127,7 +127,7 @@ Did the user specify how the response should be structured?
 
 ---
 
-### 6. Verification (Execution, Verification)
+### 6. Verification (Execution, Verification, Reusable workflow)
 
 Did the user ask how to check correctness?
 
@@ -163,6 +163,19 @@ When in doubt, redact and note that you've done so: `[API key redacted]`.
 ## Composite Score
 
 Individual dimensions are scored 1–5. The composite is reported as XX / 100 (average of applicable dimensions × 20, rounded). A prompt with no issues in any dimension scores 100 / 100.
+
+| Stage | Dimensions included in composite |
+|---|---|
+| Exploration | Goal Clarity + Privacy/Safety |
+| Diagnosis | Goal Clarity + Context Completeness + Privacy/Safety |
+| Execution | All seven dimensions |
+| Verification | Goal Clarity + Context Completeness + Input Boundaries + Output Format + Verification + Privacy/Safety |
+| Reusable workflow | Goal Clarity + Context Completeness + Input Boundaries + Constraints + Output Format + Verification + Privacy/Safety |
+| Action | Goal Clarity + Privacy/Safety |
+
+Verification prompts exclude Constraints because the user is asking for checks, review, or tests rather than an implementation plan. Reusable workflow prompts include Constraints because repeatable processes need scope, audience, and adoption boundaries.
+
+Scores are stage-relative. A prompt can score well as Exploration and then score lower as Execution after the user asks for file edits, because more dimensions apply. This is expected: the rubric raises the bar when the agent is being asked to make real changes.
 
 **Grade labels:**
 

--- a/examples/debugging-journey.md
+++ b/examples/debugging-journey.md
@@ -2,7 +2,7 @@
 
 This example follows one developer improving the same prompt across four iterations over two days. Each iteration applies one habit from the previous session's feedback.
 
-The scenario: a Jest test is failing after adding refresh-token support. The developer is using Claude Code to debug it.
+The scenario: a Jest test is failing after adding refresh-token support. The developer is using an AI coding agent to debug it.
 
 ---
 
@@ -12,7 +12,7 @@ The scenario: a Jest test is failing after adding refresh-token support. The dev
 > fix this test
 
 **Stage:** Exploration
-**Score:** 1.5/5 (as Exploration) · 1.2/5 (if Execution-ready)
+**Score:** 70/100 — Good for Exploration
 
 | Dimension | Score | Note |
 |---|---|---|
@@ -35,7 +35,7 @@ After getting a partial response, the developer now has the error output. They t
 > A Jest test is failing. Expected /login, actual /dashboard.
 
 **Stage:** Diagnosis
-**Score:** 2.8/5
+**Score:** 67/100 — Developing
 
 | Dimension | Score | Note |
 |---|---|---|
@@ -64,7 +64,7 @@ The developer now knows the relevant file and suspects a recent change.
 > Do not refactor the whole auth flow.
 
 **Stage:** Execution
-**Score:** 3.6/5
+**Score:** 60/100 — Developing
 
 | Dimension | Score | Note |
 |---|---|---|
@@ -119,7 +119,7 @@ End every debugging prompt with "Return: 1. Root cause 2. Minimal fix 3. Test co
 >   5. Edge cases to verify
 
 **Stage:** Execution
-**Score:** 4.7/5 — Excellent
+**Score:** 94/100 — Excellent
 
 | Dimension | Score | Note |
 |---|---|---|
@@ -138,11 +138,13 @@ Excellent. This is execution-ready. Claude can go directly to the fix with no fo
 
 ## What changed
 
-| Attempt | Key addition | Score jump |
+| Attempt | Stage | Key addition | Effect |
 |---|---|---|
-| 1 → 2 | Expected vs. actual behavior | +1.3 |
-| 2 → 3 | File name + constraint | +0.8 |
-| 3 → 4 | Output structure + verification | +1.1 |
+| 1 → 2 | Exploration → Diagnosis | Expected vs. actual behavior | The problem became diagnosable |
+| 2 → 3 | Diagnosis → Execution | File name + constraint | Claude had enough scope to start work |
+| 3 → 4 | Execution → Execution | Output structure + verification | The request became execution-ready |
+
+The score is stage-aware, so it is not always a straight line upward. When the prompt moves from Exploration to Execution, Prompt Sensei applies more dimensions and the bar gets higher. That is intentional: a short exploratory prompt can be reasonable early, while an implementation request needs clearer context, boundaries, and verification.
 
 The three biggest gains came from:
 1. Adding expected vs. actual (most impactful single addition for any debugging prompt)
@@ -166,4 +168,4 @@ Constraints: What should Claude not touch?
 Return:      Root cause · Fix · Test command · Edge cases
 ```
 
-Start where you are. Add one element at a time. That's how this prompt went from 1.5 to 4.7.
+Start where you are. Add one element at a time. That is how this prompt moved from a reasonable first signal to an execution-ready request.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "build": "tsc",
     "observe": "node dist/scripts/observe.js",
     "report": "node dist/scripts/report.js",
+    "check-update": "node dist/scripts/update.js --check",
+    "update": "node dist/scripts/update.js --apply",
     "clear-data": "node dist/scripts/clear.js"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "keywords": [
     "claude-code",
+    "codex",
     "prompt-engineering",
     "ai-coding",
     "developer-tools",

--- a/scripts/clear.ts
+++ b/scripts/clear.ts
@@ -15,6 +15,7 @@ import * as readline from "readline";
 const DATA_DIR = join(homedir(), ".prompt-sensei");
 const EVENTS_FILE = join(DATA_DIR, "events.jsonl");
 const CONFIG_FILE = join(DATA_DIR, "config.json");
+const UPDATE_FILE = join(DATA_DIR, "update-check.json");
 
 function countEntries(): number {
   if (!existsSync(EVENTS_FILE)) return 0;
@@ -30,6 +31,12 @@ function deleteData(all: boolean): void {
     unlinkSync(EVENTS_FILE);
     deleted++;
     console.log(`Deleted: ${EVENTS_FILE}`);
+  }
+
+  if (existsSync(UPDATE_FILE)) {
+    unlinkSync(UPDATE_FILE);
+    deleted++;
+    console.log(`Deleted: ${UPDATE_FILE}`);
   }
 
   if (all && existsSync(CONFIG_FILE)) {

--- a/scripts/observe.ts
+++ b/scripts/observe.ts
@@ -19,10 +19,12 @@ import { mkdirSync, appendFileSync, writeFileSync, existsSync, readFileSync } fr
 import { join } from "path";
 import { homedir } from "os";
 import * as readline from "readline";
+import { spawn } from "child_process";
 
 const DATA_DIR = join(homedir(), ".prompt-sensei");
 const EVENTS_FILE = join(DATA_DIR, "events.jsonl");
 const CONFIG_FILE = join(DATA_DIR, "config.json");
+const UPDATE_SCRIPT = join(__dirname, "update.js");
 
 // Patterns for redacting sensitive data before hashing
 const REDACT_PATTERNS: Array<[RegExp, string]> = [
@@ -107,6 +109,21 @@ function appendEvent(event: PromptEvent): void {
   appendFileSync(EVENTS_FILE, JSON.stringify(event) + "\n", "utf8");
 }
 
+function runBackgroundUpdateCheck(): void {
+  if (process.env["PROMPT_SENSEI_DISABLE_UPDATE_CHECK"] === "1") return;
+  if (!existsSync(UPDATE_SCRIPT)) return;
+
+  try {
+    const child = spawn(process.execPath, [UPDATE_SCRIPT, "--check", "--quiet"], {
+      detached: true,
+      stdio: "ignore",
+    });
+    child.unref();
+  } catch {
+    // Update checks are best-effort and must never block prompt observation.
+  }
+}
+
 async function readStdin(): Promise<string> {
   if (process.stdin.isTTY) return "";
   const rl = readline.createInterface({ input: process.stdin });
@@ -136,6 +153,7 @@ async function main(): Promise<void> {
         ts: new Date().toISOString(),
         type: "session-start",
       });
+      runBackgroundUpdateCheck();
       console.log(`Session started. Data: ${DATA_DIR}`);
       return;
     }
@@ -153,6 +171,7 @@ async function main(): Promise<void> {
     });
 
     console.log("Session started.");
+    runBackgroundUpdateCheck();
     return;
   }
 
@@ -163,6 +182,8 @@ async function main(): Promise<void> {
     );
     return;
   }
+
+  runBackgroundUpdateCheck();
 
   const hasObservationArgs =
     args["stage"] !== undefined ||

--- a/scripts/observe.ts
+++ b/scripts/observe.ts
@@ -4,6 +4,7 @@
  *
  * Usage:
  *   observe.js --init
+ *   observe.js --hash-only
  *   observe.js --stage execution --score 3.8 --task-type debugging --flags missing-context,no-constraints
  *
  * Raw prompt text is never stored. Only metadata: timestamp, stage, task type,
@@ -73,7 +74,7 @@ interface Config {
   v: number;
   consentGiven: boolean;
   consentAt: string;
-  storeRaw: boolean;
+  storeRaw?: boolean;
 }
 
 function loadConfig(): Config | null {
@@ -93,7 +94,7 @@ function saveConfig(config: Config): void {
 interface PromptEvent {
   v: 1;
   ts: string;
-  type: "session-start" | "prompt-observed";
+  type: "session-start" | "prompt-observed" | "prompt-hashed";
   stage?: string;
   taskType?: string;
   score?: number;
@@ -129,7 +130,6 @@ async function main(): Promise<void> {
         v: 1,
         consentGiven: true,
         consentAt: new Date().toISOString(),
-        storeRaw: false,
       });
       appendEvent({
         v: 1,
@@ -156,25 +156,43 @@ async function main(): Promise<void> {
     return;
   }
 
-  // Record a prompt observation
+  const config = loadConfig();
+  if (!config?.consentGiven) {
+    process.stderr.write(
+      "Prompt Sensei has not been initialized. Run `/prompt-sensei observe` and consent before recording observations.\n"
+    );
+    return;
+  }
+
+  const hasObservationArgs =
+    args["stage"] !== undefined ||
+    args["score"] !== undefined ||
+    args["task-type"] !== undefined ||
+    args["flags"] !== undefined;
+  const hashOnly = args["hash-only"] === true || !hasObservationArgs;
+  const stdinText = await readStdin();
+
+  if (hashOnly) {
+    if (!stdinText.trim()) return;
+    appendEvent({
+      v: 1,
+      ts: new Date().toISOString(),
+      type: "prompt-hashed",
+      promptHash: hashPrompt(stdinText),
+    });
+    return;
+  }
+
+  // Record a scored prompt observation. This path is used by the skill after it
+  // classifies and scores the prompt in conversation context.
   const stage = args["stage"] ? String(args["stage"]) : "unknown";
-  const score = args["score"] ? parseFloat(String(args["score"])) : undefined;
+  const score = args["score"] !== undefined ? parseFloat(String(args["score"])) : undefined;
   const taskType = args["task-type"] ? String(args["task-type"]) : "other";
   const flagsRaw = args["flags"] ? String(args["flags"]) : "";
   const flags = flagsRaw ? flagsRaw.split(",").map((f) => f.trim()).filter(Boolean) : [];
 
-  // Optionally hash the prompt from stdin (never store raw text)
-  let promptHash: string | undefined;
-  const storeRaw = process.env["PROMPT_SENSEI_STORE_RAW"] === "1";
-  if (!storeRaw) {
-    const stdinText = await readStdin();
-    if (stdinText.trim()) {
-      promptHash = hashPrompt(stdinText);
-    }
-  }
-
-  if (score !== undefined && (isNaN(score) || score < 0 || score > 5)) {
-    process.stderr.write("Error: --score must be between 0 and 5\n");
+  if (score !== undefined && (isNaN(score) || score < 1 || score > 5)) {
+    process.stderr.write("Error: --score must be between 1 and 5\n");
     process.exit(1);
   }
 
@@ -186,7 +204,7 @@ async function main(): Promise<void> {
     taskType,
     ...(score !== undefined && { score }),
     ...(flags.length > 0 && { flags }),
-    ...(promptHash && { promptHash }),
+    ...(stdinText.trim() && { promptHash: hashPrompt(stdinText) }),
   });
 }
 

--- a/scripts/report.ts
+++ b/scripts/report.ts
@@ -9,9 +9,12 @@
 import { readFileSync, existsSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
+import { spawn } from "child_process";
 
 const DATA_DIR = join(homedir(), ".prompt-sensei");
 const EVENTS_FILE = join(DATA_DIR, "events.jsonl");
+const UPDATE_FILE = join(DATA_DIR, "update-check.json");
+const UPDATE_SCRIPT = join(__dirname, "update.js");
 
 interface PromptEvent {
   v: number;
@@ -21,6 +24,15 @@ interface PromptEvent {
   taskType?: string;
   score?: number;
   flags?: string[];
+}
+
+interface UpdateState {
+  v: number;
+  checkedAt: string;
+  status: string;
+  branch?: string;
+  currentSha?: string;
+  remoteSha?: string;
 }
 
 interface CoachingNote {
@@ -82,6 +94,43 @@ function loadEvents(days: number): PromptEvent[] {
     }
   }
   return events;
+}
+
+function loadUpdateState(): UpdateState | null {
+  if (!existsSync(UPDATE_FILE)) return null;
+  try {
+    return JSON.parse(readFileSync(UPDATE_FILE, "utf8")) as UpdateState;
+  } catch {
+    return null;
+  }
+}
+
+function runBackgroundUpdateCheck(): void {
+  if (process.env["PROMPT_SENSEI_DISABLE_UPDATE_CHECK"] === "1") return;
+  if (!existsSync(UPDATE_SCRIPT)) return;
+
+  try {
+    const child = spawn(process.execPath, [UPDATE_SCRIPT, "--check", "--quiet"], {
+      detached: true,
+      stdio: "ignore",
+    });
+    child.unref();
+  } catch {
+    // Reports should still work if update checks fail.
+  }
+}
+
+function printUpdateNotice(): void {
+  const state = loadUpdateState();
+  if (state?.status !== "update-available") return;
+
+  console.log("\n## Update");
+  console.log(`Update available on \`${state.branch ?? "current branch"}\`.`);
+  if (state.currentSha && state.remoteSha) {
+    console.log(`- Local: ${state.currentSha.slice(0, 7)}`);
+    console.log(`- Remote: ${state.remoteSha.slice(0, 7)}`);
+  }
+  console.log("- Run `/prompt-sensei update` to update.");
 }
 
 function avg(nums: number[]): number {
@@ -236,6 +285,7 @@ function main(): void {
   const daysArg = process.argv.find((a) => a.startsWith("--days="));
   const days = daysArg ? parseInt(daysArg.split("=")[1]!) : 7;
 
+  runBackgroundUpdateCheck();
   const events = loadEvents(days);
 
   if (events.length === 0) {
@@ -243,6 +293,7 @@ function main(): void {
     console.log(
       "Activate observation with `/prompt-sensei observe` to start tracking."
     );
+    printUpdateNotice();
     return;
   }
 
@@ -265,6 +316,7 @@ function main(): void {
     console.log(
       "Activate observation with `/prompt-sensei observe` to start receiving scored feedback."
     );
+    printUpdateNotice();
     return;
   }
 
@@ -352,6 +404,8 @@ function main(): void {
       console.log(`- ${stage}: ${count} (${pct}%)`);
     }
   }
+
+  printUpdateNotice();
 
   console.log("\n## Feedback");
   console.log(generateEncouragement(avgScore100, trend100, topTask, topFlags, taskGrowthAreas));

--- a/scripts/report.ts
+++ b/scripts/report.ts
@@ -23,6 +23,40 @@ interface PromptEvent {
   flags?: string[];
 }
 
+interface CoachingNote {
+  habit: string;
+  why: string;
+  practice: string;
+}
+
+const FLAG_COACHING: Record<string, CoachingNote> = {
+  "missing-context": {
+    habit: "Add the error message, expected behavior, and recent change before asking for help.",
+    why: "Context is the difference between guessing and diagnosing.",
+    practice: "For the next three debugging prompts, include Expected, Actual, and Recent change.",
+  },
+  "no-constraints": {
+    habit: "Add one boundary such as no new dependencies, minimal diff, or do not change the public API.",
+    why: "Constraints protect the parts of the codebase you do not want the agent to redesign.",
+    practice: "For the next three implementation prompts, add a single 'Do not...' line.",
+  },
+  "no-verification": {
+    habit: "End the prompt with the exact test command or edge cases to verify.",
+    why: "Verification turns a patch request into a checkable engineering task.",
+    practice: "For the next three execution prompts, end with 'Verify with...'.",
+  },
+  "no-output-format": {
+    habit: "Ask for a clear return shape, such as root cause, fix, and test command.",
+    why: "A response format makes the answer easier to review and act on.",
+    practice: "For the next three prompts, include a short 'Return:' list.",
+  },
+  "missing-input-boundaries": {
+    habit: "Name the file, function, or line range Claude should focus on.",
+    why: "Input boundaries keep the agent from searching or editing more than needed.",
+    practice: "For the next three code prompts, include at least one file path.",
+  },
+};
+
 function loadEvents(days: number): PromptEvent[] {
   if (!existsSync(EVENTS_FILE)) return [];
 
@@ -38,7 +72,7 @@ function loadEvents(days: number): PromptEvent[] {
     try {
       const event = JSON.parse(line) as PromptEvent;
       if (
-        event.type === "prompt-observed" &&
+        (event.type === "prompt-observed" || event.type === "prompt-hashed") &&
         new Date(event.ts) >= cutoff
       ) {
         events.push(event);
@@ -69,6 +103,14 @@ function topN<T>(map: Map<T, number>, n: number): Array<[T, number]> {
     .slice(0, n);
 }
 
+function increment<T>(map: Map<T, number>, key: T): void {
+  map.set(key, (map.get(key) ?? 0) + 1);
+}
+
+function percent(count: number, total: number): string {
+  return total === 0 ? "0" : ((count / total) * 100).toFixed(0);
+}
+
 function sparkline(scores: number[]): string {
   const chars = ["▁", "▂", "▃", "▄", "▅", "▆", "▇", "█"];
   return scores
@@ -76,52 +118,114 @@ function sparkline(scores: number[]): string {
     .join("");
 }
 
+function topFlagByTask(
+  taskFlagCounts: Map<string, Map<string, number>>,
+  topTasks: Array<[string, number]>,
+  limit: number
+): Array<{ task: string; flag: string; count: number }> {
+  const rows: Array<{ task: string; flag: string; count: number }> = [];
+  for (const [task] of topTasks) {
+    const topFlag = topN(taskFlagCounts.get(task) ?? new Map<string, number>(), 1)[0];
+    if (topFlag) {
+      rows.push({ task, flag: topFlag[0], count: topFlag[1] });
+    }
+    if (rows.length >= limit) break;
+  }
+  return rows;
+}
+
+function describeStageShift(events: PromptEvent[]): string | null {
+  if (events.length < 10) return null;
+
+  const recent = events.slice(-5);
+  const previous = events.slice(-10, -5);
+  const stages = new Set<string>();
+  for (const event of [...recent, ...previous]) {
+    if (event.stage) stages.add(event.stage);
+  }
+
+  let biggestShift: { stage: string; delta: number; recentCount: number; previousCount: number } | null = null;
+  for (const stage of stages) {
+    const recentCount = recent.filter((event) => event.stage === stage).length;
+    const previousCount = previous.filter((event) => event.stage === stage).length;
+    const delta = recentCount / recent.length - previousCount / previous.length;
+    if (!biggestShift || Math.abs(delta) > Math.abs(biggestShift.delta)) {
+      biggestShift = { stage, delta, recentCount, previousCount };
+    }
+  }
+
+  if (!biggestShift || biggestShift.delta === 0) return null;
+
+  const direction = biggestShift.delta > 0 ? "more" : "less";
+  return `${direction} ${biggestShift.stage} prompts recently (${biggestShift.recentCount}/5 vs ${biggestShift.previousCount}/5 previous)`;
+}
+
+function momentumMessage(trend100: number): string {
+  if (trend100 > 8) {
+    return "Your recent prompts are getting noticeably stronger.";
+  }
+  if (trend100 > 4) {
+    return "Your scores are trending upward. The practice is working.";
+  }
+  if (trend100 < -8) {
+    return "Your recent prompts are scoring lower, which often means the work got harder or less familiar.";
+  }
+  if (trend100 < -4) {
+    return "Your scores dipped recently. That can happen when tasks get harder.";
+  }
+  return "Your scores are steady. This is a good moment to focus on one repeatable habit.";
+}
+
+function scoreBandMessage(avgScore100: number, topTask: string): string {
+  if (avgScore100 >= 90) {
+    return `Your ${topTask} prompts are consistently execution-ready. Keep protecting that clarity when tasks get bigger.`;
+  }
+  if (avgScore100 >= 70) {
+    return `Your ${topTask} prompts are already useful. One sharper habit can move them from good to consistently excellent.`;
+  }
+  if (avgScore100 >= 50) {
+    return `Your ${topTask} prompts are in the developing range. The next gain is likely one missing detail, not a full rewrite.`;
+  }
+  return `Your ${topTask} prompts are still mostly early-stage. Start by making the desired action unmistakable.`;
+}
+
+function formatCoaching(area: { task: string; flag: string; count: number }): string | null {
+  const note = FLAG_COACHING[area.flag];
+  if (!note) return null;
+
+  return [
+    `\nNext habit for ${area.task}: ${note.habit}`,
+    `Why it matters: ${note.why}`,
+    `Practice: ${note.practice}`,
+  ].join("\n");
+}
+
 function generateEncouragement(
   avgScore100: number,
   trend100: number,
-  topStage: string,
-  topFlags: Array<[string, number]>
+  topTask: string,
+  topFlags: Array<[string, number]>,
+  taskGrowthAreas: Array<{ task: string; flag: string; count: number }>
 ): string {
   const lines: string[] = [];
 
-  if (trend100 > 4) {
-    lines.push("Your scores are trending upward. The practice is working.");
-  } else if (trend100 < -4) {
-    lines.push(
-      "Your scores dipped recently. That can happen when tasks get harder — keep going."
-    );
-  } else {
-    lines.push("Your scores are steady. Ready to push to the next level?");
-  }
+  lines.push(momentumMessage(trend100));
+  lines.push(scoreBandMessage(avgScore100, topTask));
 
-  if (avgScore100 >= 90) {
-    lines.push("You are consistently writing execution-ready prompts. That's a real skill.");
-  } else if (avgScore100 >= 70) {
-    lines.push(
-      "You are writing good prompts. One more habit — verification steps — will take you to the next level."
-    );
-  } else if (avgScore100 >= 50) {
-    lines.push(
-      "You are in the developing stage. The gap between where you are and 'good' is smaller than it feels."
-    );
-  } else {
-    lines.push(
-      "Every expert started with exploration prompts. Focus on one dimension at a time."
-    );
+  const topTaskArea = taskGrowthAreas.find((area) => area.task === topTask) ?? taskGrowthAreas[0];
+  if (topTaskArea) {
+    const coaching = formatCoaching(topTaskArea);
+    if (coaching) {
+      lines.push(coaching);
+      return lines.join("\n");
+    }
   }
 
   if (topFlags.length > 0) {
     const [topFlag] = topFlags[0];
-    const flagHints: Record<string, string> = {
-      "missing-context": "Try adding the error message or stack trace to every debugging prompt.",
-      "no-constraints": "Add at least one constraint to implementation prompts ('don't change the API', 'no new deps').",
-      "no-verification": "End implementation prompts with 'Return: test command and edge cases to verify.'",
-      "no-output-format": "Specify the format: 'Return: 1. Root cause 2. Fix 3. Test command'",
-      "missing-input-boundaries": "Name the specific file and function, not just the module.",
-    };
-    const hint = flagHints[topFlag];
-    if (hint) {
-      lines.push(`\nMain growth area: ${hint}`);
+    const coaching = formatCoaching({ task: topTask, flag: topFlag, count: 0 });
+    if (coaching) {
+      lines.push(coaching);
     }
   }
 
@@ -142,7 +246,28 @@ function main(): void {
     return;
   }
 
-  const scores = events.map((e) => e.score).filter((s): s is number => s !== undefined);
+  const scoredEvents = events.filter(
+    (event) => event.type === "prompt-observed" && typeof event.score === "number"
+  );
+  const hashOnlyCount = events.filter((event) => event.type === "prompt-hashed").length;
+  const scores = scoredEvents.map((e) => e.score).filter((s): s is number => s !== undefined);
+
+  if (scores.length === 0) {
+    console.log("# Prompt Sensei Report");
+    console.log(`Observed 0 scored prompts in the last ${days} days.`);
+    if (hashOnlyCount > 0) {
+      console.log(`\n**Hash-only prompt captures:** ${hashOnlyCount}`);
+      console.log(
+        "These came from the local hook and are excluded from scoring because no stage or score was recorded."
+      );
+    }
+    console.log("\nNo scored session data found.");
+    console.log(
+      "Activate observation with `/prompt-sensei observe` to start receiving scored feedback."
+    );
+    return;
+  }
+
   const avgScore = avg(scores);
   const recent5 = scores.slice(-5);
   const older5 = scores.slice(-10, -5);
@@ -153,35 +278,53 @@ function main(): void {
   const stageCounts = new Map<string, number>();
   const taskCounts = new Map<string, number>();
   const flagCounts = new Map<string, number>();
+  const taskFlagCounts = new Map<string, Map<string, number>>();
 
-  for (const event of events) {
+  for (const event of scoredEvents) {
     if (event.stage) {
-      stageCounts.set(event.stage, (stageCounts.get(event.stage) ?? 0) + 1);
+      increment(stageCounts, event.stage);
     }
     if (event.taskType) {
-      taskCounts.set(event.taskType, (taskCounts.get(event.taskType) ?? 0) + 1);
+      increment(taskCounts, event.taskType);
     }
     for (const flag of event.flags ?? []) {
-      flagCounts.set(flag, (flagCounts.get(flag) ?? 0) + 1);
+      increment(flagCounts, flag);
+      const task = event.taskType ?? "unknown";
+      let nested = taskFlagCounts.get(task);
+      if (!nested) {
+        nested = new Map<string, number>();
+        taskFlagCounts.set(task, nested);
+      }
+      increment(nested, flag);
     }
   }
 
   const topStage = topN(stageCounts, 1)[0]?.[0] ?? "unknown";
-  const topTask = topN(taskCounts, 1)[0]?.[0] ?? "unknown";
+  const topTasks = topN(taskCounts, 3);
+  const topTask = topTasks[0]?.[0] ?? "unknown";
   const topFlags = topN(flagCounts, 3);
+  const taskGrowthAreas = topFlagByTask(taskFlagCounts, topTasks, 3);
+  const stageShift = describeStageShift(scoredEvents);
 
   const avgScore100 = Math.round(avgScore * 20);
   const trend100 = Math.round(trend * 20);
   const trendSymbol = trend100 > 2 ? "↑" : trend100 < -2 ? "↓" : "→";
 
   console.log("# Prompt Sensei Report");
-  console.log(`Observed ${events.length} prompts in the last ${days} days.\n`);
+  console.log(`Observed ${scores.length} scored prompts in the last ${days} days.`);
+  if (hashOnlyCount > 0) {
+    console.log(`Hash-only prompt captures: ${hashOnlyCount} (excluded from scoring)`);
+  }
+  console.log("");
   console.log(`**Average score:**    ${avgScore100} / 100  (${gradeLabel(avgScore100)})`);
   if (scores.length >= 10) {
     console.log(`**Trend:**            ${trendSymbol}  ${Math.abs(trend100)} pts vs previous 5 prompts`);
   }
   console.log(`**Most common type:** ${topTask}`);
   console.log(`**Most common stage:** ${topStage}`);
+  if (stageShift) {
+    console.log(`**Stage trend:**      ${stageShift}`);
+  }
 
   if (scores.length >= 3) {
     console.log(`\n**Score history:**    ${sparkline(scores.slice(-20))}`);
@@ -194,17 +337,24 @@ function main(): void {
     }
   }
 
+  if (taskGrowthAreas.length > 0) {
+    console.log("\n## Growth area by task type");
+    for (const area of taskGrowthAreas) {
+      console.log(`- ${area.task}: ${area.flag} (${area.count}×)`);
+    }
+  }
+
   const stageEntries = topN(stageCounts, 5);
   if (stageEntries.length > 0) {
     console.log("\n## Stage breakdown");
     for (const [stage, count] of stageEntries) {
-      const pct = ((count / events.length) * 100).toFixed(0);
+      const pct = percent(count, scoredEvents.length);
       console.log(`- ${stage}: ${count} (${pct}%)`);
     }
   }
 
   console.log("\n## Feedback");
-  console.log(generateEncouragement(avgScore100, trend100, topStage, topFlags));
+  console.log(generateEncouragement(avgScore100, trend100, topTask, topFlags, taskGrowthAreas));
 }
 
 main();

--- a/scripts/update.ts
+++ b/scripts/update.ts
@@ -1,0 +1,206 @@
+#!/usr/bin/env node
+/**
+ * Check for and apply Prompt Sensei updates.
+ *
+ * Usage:
+ *   update.js --check [--quiet] [--force]
+ *   update.js --apply
+ *
+ * The check path is networked and cached. It compares the local git HEAD to the
+ * remote HEAD for the current branch and stores the result in
+ * ~/.prompt-sensei/update-check.json.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { homedir } from "os";
+import { join, resolve } from "path";
+import { execFileSync, spawnSync } from "child_process";
+
+const DATA_DIR = join(homedir(), ".prompt-sensei");
+const UPDATE_FILE = join(DATA_DIR, "update-check.json");
+const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+// dist/scripts/update.js -> skill root
+const SKILL_ROOT = resolve(__dirname, "..", "..");
+
+interface UpdateState {
+  v: 1;
+  checkedAt: string;
+  status: "up-to-date" | "update-available" | "unknown";
+  branch?: string;
+  currentSha?: string;
+  remoteSha?: string;
+  message?: string;
+}
+
+function ensureDataDir(): void {
+  if (!existsSync(DATA_DIR)) {
+    mkdirSync(DATA_DIR, { recursive: true });
+  }
+}
+
+function parseArgs(argv: string[]): Record<string, boolean> {
+  const result: Record<string, boolean> = {};
+  for (let i = 2; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg.startsWith("--")) {
+      result[arg.slice(2)] = true;
+    }
+  }
+  return result;
+}
+
+function git(args: string[]): string {
+  return execFileSync("git", ["-C", SKILL_ROOT, ...args], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+function loadState(): UpdateState | null {
+  if (!existsSync(UPDATE_FILE)) return null;
+  try {
+    return JSON.parse(readFileSync(UPDATE_FILE, "utf8")) as UpdateState;
+  } catch {
+    return null;
+  }
+}
+
+function saveState(state: UpdateState): void {
+  ensureDataDir();
+  writeFileSync(UPDATE_FILE, JSON.stringify(state, null, 2) + "\n", "utf8");
+}
+
+function shouldUseCachedState(force: boolean): boolean {
+  if (force) return false;
+  const state = loadState();
+  if (!state) return false;
+  const checkedAt = new Date(state.checkedAt).getTime();
+  return Number.isFinite(checkedAt) && Date.now() - checkedAt < CHECK_INTERVAL_MS;
+}
+
+function isGitInstall(): boolean {
+  try {
+    return git(["rev-parse", "--is-inside-work-tree"]) === "true";
+  } catch {
+    return false;
+  }
+}
+
+function currentBranch(): string {
+  return git(["rev-parse", "--abbrev-ref", "HEAD"]);
+}
+
+function checkForUpdate(force: boolean, quiet: boolean): UpdateState {
+  if (shouldUseCachedState(force)) {
+    const state = loadState()!;
+    if (!quiet) printState(state);
+    return state;
+  }
+
+  if (!isGitInstall()) {
+    const state: UpdateState = {
+      v: 1,
+      checkedAt: new Date().toISOString(),
+      status: "unknown",
+      message: "Prompt Sensei is not installed from a git checkout, so update checks are unavailable.",
+    };
+    saveState(state);
+    if (!quiet) printState(state);
+    return state;
+  }
+
+  try {
+    const branch = currentBranch();
+    const currentSha = git(["rev-parse", "HEAD"]);
+    const remoteLine = git(["ls-remote", "origin", `refs/heads/${branch}`]);
+    const remoteSha = remoteLine.split(/\s+/)[0];
+
+    const state: UpdateState = {
+      v: 1,
+      checkedAt: new Date().toISOString(),
+      status: remoteSha && remoteSha !== currentSha ? "update-available" : "up-to-date",
+      branch,
+      currentSha,
+      remoteSha,
+    };
+    saveState(state);
+    if (!quiet) printState(state);
+    return state;
+  } catch (err) {
+    const state: UpdateState = {
+      v: 1,
+      checkedAt: new Date().toISOString(),
+      status: "unknown",
+      message: err instanceof Error ? err.message : String(err),
+    };
+    saveState(state);
+    if (!quiet) printState(state);
+    return state;
+  }
+}
+
+function printState(state: UpdateState): void {
+  if (state.status === "update-available") {
+    console.log(`# Prompt Sensei Update\n\nUpdate available on \`${state.branch}\`.`);
+    console.log(`Local:  ${state.currentSha?.slice(0, 7)}`);
+    console.log(`Remote: ${state.remoteSha?.slice(0, 7)}`);
+    console.log("\nRun `/prompt-sensei update` to update.");
+    return;
+  }
+
+  if (state.status === "up-to-date") {
+    console.log("Prompt Sensei is up to date.");
+    return;
+  }
+
+  console.log("Prompt Sensei update status is unknown.");
+  if (state.message) {
+    console.log(state.message);
+  }
+}
+
+function runStep(command: string, args: string[]): void {
+  console.log(`$ ${[command, ...args].join(" ")}`);
+  const result = spawnSync(command, args, {
+    cwd: SKILL_ROOT,
+    stdio: "inherit",
+  });
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}
+
+function applyUpdate(): void {
+  if (!isGitInstall()) {
+    process.stderr.write("Prompt Sensei is not installed from a git checkout; update is unavailable.\n");
+    process.exit(1);
+  }
+
+  const status = git(["status", "--porcelain"]);
+  if (status.trim()) {
+    process.stderr.write(
+      "Working tree has local changes. Commit, stash, or discard them before running `/prompt-sensei update`.\n"
+    );
+    process.exit(1);
+  }
+
+  const branch = currentBranch();
+  runStep("git", ["pull", "--ff-only", "origin", branch]);
+  runStep("npm", ["install"]);
+  runStep("npm", ["run", "build"]);
+  checkForUpdate(true, false);
+}
+
+function main(): void {
+  const args = parseArgs(process.argv);
+
+  if (args["apply"] || args["update"]) {
+    applyUpdate();
+    return;
+  }
+
+  checkForUpdate(Boolean(args["force"]), Boolean(args["quiet"]));
+}
+
+main();


### PR DESCRIPTION
## Summary

Prepare the v0.0.1 release for Prompt Sensei.

## Changes

- Make observation privacy truthful by requiring consent before recording events.
- Add explicit hash-only hook mode and separate hash-only captures from scored observations.
- Normalize stage-aware scoring across Exploration, Diagnosis, Execution, Verification, Reusable workflow, and Action prompts.
- Improve report feedback with task-specific growth areas, stage trends, and deterministic coaching notes.
- Add a cached update-check workflow and explicit `/prompt-sensei update` command.
- Add Codex-compatible skill metadata and install guidance while keeping Claude Code hook behavior documented as Claude-specific.
- Add `README-zh.md` for Chinese-language launch/publicity and `CLAUDE.md` maintainer guidance.
- Polish observe UX with absolute script paths, a scored-observation success line, and clearer Claude Code hook guidance.
- Update README, philosophy, privacy docs, scoring rubric, and debugging journey examples.

## Validation

- `npm run build`
- `git diff --check`
- `node dist/scripts/update.js --check --force` with a temporary home directory
- `node ~/.claude/skills/prompt-sensei/dist/scripts/observe.js --stage execution --score 4 --task-type debugging`
- Grepped `SKILL.md` to confirm `dist/scripts/` references use absolute paths
- Confirmed `README.md` documents `UserPromptSubmit` before `Why Prompt Sensei?`
- Manual smoke test for report output with scored, hash-only, and update-available states
