### PR TITLE
v0.3.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This project is a local-first prompt-coaching skill for AI coding agents. Keep c
 
 ## When Changing Behavior
 
-- Update `SKILL.md` when command behavior, scoring behavior, consent, storage, update checks, or report output changes.
+- Update `SKILL.md` when command behavior, scoring behavior, consent, storage, lookback, update checks, or report output changes.
 - Update both `README.md` and `README-zh.md` for user-facing behavior, install steps, command lists, examples, and privacy notes.
 - Update `docs/privacy.md` for any storage, deletion, or network behavior changes.
 - Update `docs/scoring-rubric.md` when stage formulas, dimensions, flags, or score labels change.
@@ -19,6 +19,8 @@ This project is a local-first prompt-coaching skill for AI coding agents. Keep c
 - Run `npm run build` after TypeScript changes.
 - Do not add network behavior except for explicit, documented update checks.
 - Do not store raw prompt text. Use metadata and redacted hashes only.
+- Lookback may read selected raw local history after separate consent, but must not copy raw history, prompt hashes, or derived lookback metadata into Prompt Sensei storage by default.
+- If saved reports are added or changed, keep `/prompt-sensei clear` and `docs/privacy.md` in sync.
 - In `SKILL.md`, prefer absolute script paths for Claude Code examples, such as `node ~/.claude/skills/prompt-sensei/dist/scripts/observe.js`, to avoid cwd-reset warnings.
 
 ## Validation
@@ -37,12 +39,20 @@ node dist/scripts/update.js --check --force
 node dist/scripts/report.js
 ```
 
+For lookback-related changes, also smoke test:
+
+```bash
+node dist/scripts/lookback.js --help
+node dist/scripts/lookback.js --discover --max-sessions 3
+```
+
 ## Release Notes
 
 PR descriptions should mention:
 
 - user-facing command changes
 - improve-mode or prompt-gallery changes
+- lookback behavior or saved report changes
 - storage or privacy changes
 - report output changes
 - validation performed

--- a/README-zh.md
+++ b/README-zh.md
@@ -33,6 +33,8 @@ git clone https://github.com/chengzhongwei/Prompt-sensei ~/.claude/skills/prompt
 (cd ~/.claude/skills/prompt-sensei && npm install && npm run build)
 ```
 
+然后在 Claude Code 里用 `/prompt-sensei observe` 启动实时反馈。
+
 安装到 Codex：
 
 ```bash
@@ -40,7 +42,9 @@ git clone https://github.com/chengzhongwei/Prompt-sensei ~/.codex/skills/prompt-
 (cd ~/.codex/skills/prompt-sensei && npm install && npm run build)
 ```
 
-启动实时反馈：
+然后用自然语言告诉 Codex：`Use prompt-sensei observe mode.`
+
+在 Claude Code 里启动实时反馈：
 
 ```txt
 /prompt-sensei observe
@@ -97,6 +101,8 @@ Prompt Sensei 最适合在能直接加载 skill 的工具里使用。
 
 如果 Claude Code 或 Codex 是在 IDE plugin 里运行，只要它能访问已安装的 skill，就可以使用同一套 Prompt Sensei 工作流。
 
+`/prompt-sensei observe` 是 Claude Code 的 skill 命令。在 Codex 或其他不支持 slash command 的环境里，要用自然语言触发，而且效果取决于当前 agent 是否加载到了这个 skill。`npm run init` 只会创建本地授权和会话记录，不会自动让 agent 开始追加实时评分。
+
 ---
 
 ## 命令
@@ -119,9 +125,17 @@ Prompt Sensei 最适合在能直接加载 skill 的工具里使用。
 在 Codex 里可以用自然语言触发：
 
 ```txt
+Use prompt-sensei observe mode.
 Use prompt-sensei to improve this prompt: "fix this test"
 Use prompt-sensei to look back at my recent prompts.
 Use prompt-sensei to show my report.
+```
+
+如果只是检查本地脚本：
+
+```bash
+npm run init       # 创建本地授权和会话记录
+npm run observe    # 交互式运行时显示 observe 脚本用法
 ```
 
 ---
@@ -165,6 +179,8 @@ Next habit:       End prompts with the exact test command or edge cases.
 - 分析单个会话或全部会话
 - 生成逐条反馈或完整回顾报告
 - 在你确认后保存 markdown 报告
+
+流程会一步一步引导你选择：先从可见的会话列表里选择，再选分析形式，再选 prompt 数量，最后确认授权。
 
 Lookback 只会在本地读取历史，先脱敏再交给当前 AI agent 分析。默认不保存原始历史、不保存 prompt hash，也不把分析结果写入普通 report 数据。
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -4,7 +4,7 @@
 
 [English](README.md)
 
-Prompt Sensei 是一个面向 Claude Code 和 Codex 的本地优先 prompt 教练。它会根据你当前所处的阶段给反馈，把粗糙的 prompt 改成更可执行的版本，并帮助你一次练好一个习惯。
+Prompt Sensei 是一个面向 Claude Code 和 Codex 的本地优先 prompt 教练，也适用于能加载这些 skill 的 IDE/plugin 环境。它会根据你当前所处的阶段给反馈，把粗糙的 prompt 改成更可执行的版本，在你允许时回看本地历史，并帮助你一次练好一个习惯。
 
 没有云端服务。没有遥测。没有排行榜。默认不保存原始 prompt。
 
@@ -86,16 +86,30 @@ Habit to practice next:
 
 ---
 
+## 支持环境
+
+Prompt Sensei 最适合在能直接加载 skill 的工具里使用。
+
+| 使用方式 | 环境 |
+|---|---|
+| 直接用 skill 命令，例如 `/prompt-sensei improve "fix this test"` | Claude Code，以及兼容 Claude Code skill 的环境 |
+| 用自然语言触发，例如 `Use prompt-sensei to improve this prompt...` | Codex，以及不支持 slash command 的 IDE/plugin 环境 |
+
+如果 Claude Code 或 Codex 是在 IDE plugin 里运行，只要它能访问已安装的 skill，就可以使用同一套 Prompt Sensei 工作流。
+
+---
+
 ## 命令
 
 ```txt
-/prompt-sensei [observe|stop|improve|report|help|clear|update]
+/prompt-sensei [observe|stop|improve|lookback|report|help|clear|update]
 ```
 
 ```txt
 /prompt-sensei observe              # 开始实时反馈
 /prompt-sensei stop                 # 停止本次会话反馈
 /prompt-sensei improve "fix this"   # 改写 prompt，并给一个练习建议
+/prompt-sensei lookback             # 分析选中的本地 prompt 历史
 /prompt-sensei report               # 查看本地趋势
 /prompt-sensei update               # 拉取最新版本并重新构建
 /prompt-sensei clear                # 删除本地 Prompt Sensei 数据
@@ -106,6 +120,7 @@ Habit to practice next:
 
 ```txt
 Use prompt-sensei to improve this prompt: "fix this test"
+Use prompt-sensei to look back at my recent prompts.
 Use prompt-sensei to show my report.
 ```
 
@@ -137,6 +152,21 @@ Next habit:       End prompts with the exact test command or edge cases.
 ```
 
 完整理念见 [docs/philosophy.md](docs/philosophy.md)。评分细节见 [docs/scoring-rubric.md](docs/scoring-rubric.md)。
+
+---
+
+## Lookback
+
+`/prompt-sensei lookback` 会在你单独同意后，分析选中的本地 Claude Code 或 Codex 历史。
+
+它可以：
+
+- 自动发现最近的 Claude Code 和 Codex 会话
+- 分析单个会话或全部会话
+- 生成逐条反馈或完整回顾报告
+- 在你确认后保存 markdown 报告
+
+Lookback 只会在本地读取历史，先脱敏再交给当前 AI agent 分析。默认不保存原始历史、不保存 prompt hash，也不把分析结果写入普通 report 数据。
 
 ---
 
@@ -176,8 +206,9 @@ Prompt 往往包含业务逻辑、调试细节和未完成的想法，所以 Pro
 - `~/.prompt-sensei/events.jsonl` — 观察日志
 - `~/.prompt-sensei/config.json` — 同意记录
 - `~/.prompt-sensei/update-check.json` — 更新检查缓存
+- `~/.prompt-sensei/reports/` — 可选保存的 lookback 报告
 
-默认不保存原始 prompt，也不会把 prompt、分数、报告或本地日志发送到任何服务。
+Prompt Sensei 的本地脚本不会把 prompt、分数、报告或本地日志发送到任何服务。Lookback 会在你单独同意后，把脱敏后的用户 prompt 交给当前 AI agent 分析。
 
 更多细节见 [docs/privacy.md](docs/privacy.md)。
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ git clone https://github.com/chengzhongwei/Prompt-sensei ~/.claude/skills/prompt
 (cd ~/.claude/skills/prompt-sensei && npm install && npm run build)
 ```
 
+Then start live coaching with `/prompt-sensei observe` inside Claude Code.
+
 Install for Codex:
 
 ```bash
@@ -40,7 +42,9 @@ git clone https://github.com/chengzhongwei/Prompt-sensei ~/.codex/skills/prompt-
 (cd ~/.codex/skills/prompt-sensei && npm install && npm run build)
 ```
 
-Start live coaching:
+Then ask Codex in natural language: `Use prompt-sensei observe mode.`
+
+Start live coaching in Claude Code:
 
 ```txt
 /prompt-sensei observe
@@ -97,6 +101,8 @@ Prompt Sensei works best when the host tool can load the skill directly.
 
 If Claude Code or Codex is running inside an IDE plugin and can access the installed skill, use the same Prompt Sensei workflow there.
 
+`/prompt-sensei observe` is a Claude Code skill command. In Codex and other hosts without slash commands, natural-language requests depend on the host agent loading the installed skill. `npm run init` only creates Prompt Sensei's local consent/session record; it does not turn on live coaching by itself.
+
 ---
 
 ## Commands
@@ -119,9 +125,17 @@ If Claude Code or Codex is running inside an IDE plugin and can access the insta
 For Codex, use natural language:
 
 ```txt
+Use prompt-sensei observe mode.
 Use prompt-sensei to improve this prompt: "fix this test"
 Use prompt-sensei to look back at my recent prompts.
 Use prompt-sensei to show my report.
+```
+
+For direct script checks:
+
+```bash
+npm run init       # create local consent/session records
+npm run observe    # show observe-script usage when run interactively
 ```
 
 ---
@@ -165,6 +179,8 @@ It can:
 - analyze one session or all sessions
 - generate one-by-one coaching or a full lookback report
 - save a markdown report only after confirmation
+
+The flow is guided one step at a time: choose from a visible session list, choose the analysis format, choose the prompt count, then confirm consent.
 
 Lookback reads raw history locally, redacts user prompts before analysis, and does not store raw history, prompt hashes, or derived metadata by default.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [中文说明](README-zh.md)
 
-Prompt Sensei is a quiet, local-first prompt coach for Claude Code and Codex. It gives stage-aware feedback, rewrites rough prompts into better ones, and helps you practice one habit at a time.
+Prompt Sensei is a quiet, local-first prompt coach for Claude Code and Codex, including IDE/plugin environments that can load those skills. It gives stage-aware feedback, rewrites rough prompts into better ones, looks back on local history when you ask, and helps you practice one habit at a time.
 
 No cloud. No telemetry. No leaderboard. No raw prompt archive.
 
@@ -86,16 +86,30 @@ See [examples/prompt-gallery.md](examples/prompt-gallery.md) for more copyable b
 
 ---
 
+## Supported Environments
+
+Prompt Sensei works best when the host tool can load the skill directly.
+
+| Invocation style | Environments |
+|---|---|
+| Direct skill command, e.g. `/prompt-sensei improve "fix this test"` | Claude Code and compatible Claude Code skill environments |
+| Natural language, e.g. `Use prompt-sensei to improve this prompt...` | Codex and IDE/plugin environments where slash commands are not available |
+
+If Claude Code or Codex is running inside an IDE plugin and can access the installed skill, use the same Prompt Sensei workflow there.
+
+---
+
 ## Commands
 
 ```txt
-/prompt-sensei [observe|stop|improve|report|help|clear|update]
+/prompt-sensei [observe|stop|improve|lookback|report|help|clear|update]
 ```
 
 ```txt
 /prompt-sensei observe              # start live coaching
 /prompt-sensei stop                 # stop coaching this session
 /prompt-sensei improve "fix this"   # rewrite a prompt with one teaching note
+/prompt-sensei lookback             # analyze selected local prompt history
 /prompt-sensei report               # show local session trends
 /prompt-sensei update               # pull latest version and rebuild
 /prompt-sensei clear                # delete local Prompt Sensei data
@@ -106,6 +120,7 @@ For Codex, use natural language:
 
 ```txt
 Use prompt-sensei to improve this prompt: "fix this test"
+Use prompt-sensei to look back at my recent prompts.
 Use prompt-sensei to show my report.
 ```
 
@@ -137,6 +152,21 @@ Next habit:       End prompts with the exact test command or edge cases.
 ```
 
 For the full philosophy, read [docs/philosophy.md](docs/philosophy.md). For scoring details, read [docs/scoring-rubric.md](docs/scoring-rubric.md).
+
+---
+
+## Lookback
+
+`/prompt-sensei lookback` analyzes selected local Claude Code or Codex history after separate consent.
+
+It can:
+
+- find recent Claude Code and Codex sessions
+- analyze one session or all sessions
+- generate one-by-one coaching or a full lookback report
+- save a markdown report only after confirmation
+
+Lookback reads raw history locally, redacts user prompts before analysis, and does not store raw history, prompt hashes, or derived metadata by default.
 
 ---
 
@@ -176,8 +206,9 @@ After consent, it stores local metadata only:
 - `~/.prompt-sensei/events.jsonl` — observation log
 - `~/.prompt-sensei/config.json` — consent record
 - `~/.prompt-sensei/update-check.json` — cached update status
+- `~/.prompt-sensei/reports/` — optional saved lookback reports
 
-It does not store raw prompt text by default, and it never sends prompt text, scores, reports, or local event data to a service.
+Prompt Sensei's local scripts do not send prompt text, scores, reports, or local event data to a service. Lookback may show redacted user prompts to the current AI agent after separate consent.
 
 See [docs/privacy.md](docs/privacy.md) for details.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -30,6 +30,8 @@ If the user asks for `/prompt-sensei review`, `/prompt-sensei score`, "review my
 
 In Codex or other environments without slash-command support, treat natural-language requests such as "use prompt-sensei", "improve this prompt", "look back at my prompt history", or "show my prompt-sensei report" as equivalent invocations.
 
+`/prompt-sensei observe` is a host skill command. The local script `observe.js --init` only creates the local consent/session record; it does not make the host agent append live coaching lines by itself. In Codex or other hosts without slash commands, explain that the user should ask in natural language, e.g. "Use prompt-sensei observe mode."
+
 When running bundled scripts, use the installed skill root:
 - Claude Code default: `~/.claude/skills/prompt-sensei`
 - Codex default: `~/.codex/skills/prompt-sensei`
@@ -179,6 +181,12 @@ When the user activates `/prompt-sensei observe`:
    - On confirmation, run the observe init script by absolute path, for example `node ~/.claude/skills/prompt-sensei/dist/scripts/observe.js --init` or `node ~/.codex/skills/prompt-sensei/dist/scripts/observe.js --init`.
 
 3. After each subsequent user message this session:
+   - If the prompt is low-signal control text such as a slash-command wrapper, a one-word confirmation, a numeric menu selection, a "just reply ..." test, or a context-resume summary, do not score it. Append only:
+     ```
+     > **[[Sensei: skipped grading for low-signal prompt]]()**
+     ```
+   - Do not run the observe script for skipped low-signal prompts.
+   - While observation mode is active, the Sensei line is still required even if the user asks for an exact or "reply only" response. Only omit it after `/prompt-sensei stop`.
    - Classify the prompt stage
    - Score it on the relevant dimensions
    - Convert the composite score (1–5) to a 100-point display score by multiplying by 20 and rounding to the nearest integer
@@ -344,22 +352,42 @@ node ~/.claude/skills/prompt-sensei/dist/scripts/lookback.js --discover
 
 Use the installed skill root for the current environment, e.g. `~/.codex/skills/prompt-sensei` in Codex.
 
-2. Ask the user to choose one source:
-   - select one discovered session
-   - auto select all sessions
-   - manual path/source (ask whether it is Claude Code or Codex if the path does not make that obvious)
+2. Re-present the discovered sessions in the chat before asking the user to choose. Do not assume the user can see tool output. Show a compact list with the session number, source, latest timestamp, optional title, and a short path hint. If discovery returns many sessions, show the most recent 10 and explain that manual path is also available.
 
-3. Ask for analysis format:
-   - `one-by-one` — concise coaching for selected prompts
-   - `report` — a longer lookback report with repeated patterns and 1-5 tips
+3. Guide the user with one selection question at a time. Ask the next question only after the user answers the current one. Do not ask for source, format, limit, and consent in the same message.
 
-4. Ask how many recent user prompts to analyze:
-   - default: `30`
-   - accept a number or `all`
-   - if the number is greater than `50` or the user chooses `all`, ask for confirmation before extraction
-   - hard cap: `500`
+4. Ask the user to choose what to analyze using a visible picker:
 
-5. Show this consent text before reading history:
+```
+Choose what to analyze:
+1. <source> · <latest timestamp> · <title or path hint>
+2. <source> · <latest timestamp> · <title or path hint>
+...
+A. All discovered sessions
+M. Manual path/source
+```
+
+If the user chooses a session number, use the matching discovered session path. If the user chooses `M`, ask the source type first (`Claude Code` or `Codex`) and then ask for the file or directory path.
+
+5. Ask for analysis format:
+
+```
+Choose analysis format:
+1. Full report
+2. One-by-one coaching
+```
+
+Map `Full report` to `report` and `One-by-one coaching` to `one-by-one`.
+
+6. Ask how many recent user prompts to analyze:
+
+```
+How many recent user prompts should I analyze? Press Enter for 30, enter a number, or type all.
+```
+
+Default to `30`, accept a number or `all`, and use a hard cap of `500`. If the number is greater than `50` or the user chooses `all`, ask for confirmation as a separate follow-up question before extraction.
+
+7. Show this consent text before reading history:
 
 ```
 Prompt Sensei will read selected local conversation history and redact user prompts before analysis.
@@ -372,22 +400,22 @@ Continue? (yes / no)
 
 If the user does not consent, stop.
 
-6. Extract the selected history:
+8. Extract the selected history:
    - one discovered session: `node ~/.claude/skills/prompt-sensei/dist/scripts/lookback.js --extract --path <session-jsonl-path> --mode <report|one-by-one> --limit <number|all>`
    - all sessions: `node ~/.claude/skills/prompt-sensei/dist/scripts/lookback.js --extract --source all --session all --mode <report|one-by-one> --limit <number|all>`
    - manual path: `node ~/.claude/skills/prompt-sensei/dist/scripts/lookback.js --extract --source <claude|codex> --path <file-or-dir> --mode <report|one-by-one> --limit <number|all>`
 
-7. Analyze only user prompts. Do not analyze assistant responses.
+9. Analyze only user prompts. Do not analyze assistant responses.
 
-8. Avoid direct quotes from the prompts by default. Give direct advice such as "your prompt did not mention which test failed" rather than quoting the prompt text.
+10. Avoid direct quotes from the prompts by default. Give direct advice such as "your prompt did not mention which test failed" rather than quoting the prompt text.
 
-9. For `one-by-one`, provide concise feedback per prompt. For `report`, include:
+11. For `one-by-one`, provide concise feedback per prompt. For `report`, include:
    - repeated prompting patterns
    - strongest prompt habits
    - 1-5 next habits depending on history length
    - a short practice recommendation
 
-10. Ask whether to save the generated markdown report. Save only after explicit confirmation:
+12. Ask whether to save the generated markdown report. Save only after explicit confirmation:
 
 ```bash
 node ~/.claude/skills/prompt-sensei/dist/scripts/lookback.js --save-report --title "Prompt Sensei Lookback"

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: prompt-sensei
-description: Stage-aware prompt coaching, prompt improvement, prompting habit feedback, and local reports about prompt quality for AI coding agents such as Claude Code or Codex.
-argument-hint: [observe|stop|improve|report|help|clear|update]
+description: Stage-aware prompt coaching, prompt improvement, lookback analysis, prompting habit feedback, and local reports about prompt quality for AI coding agents such as Claude Code or Codex.
+argument-hint: [observe|stop|improve|lookback|report|help|clear|update]
 ---
 
 # Prompt Sensei
@@ -21,17 +21,19 @@ This skill is triggered by `/prompt-sensei`. Read the arguments the user provide
 - `/prompt-sensei stop` — deactivate observation mode for this session
 - `/prompt-sensei help` — show available commands
 - `/prompt-sensei improve <prompt>` — score a specific prompt and rewrite it with a minimal, copyable upgrade
+- `/prompt-sensei lookback` — analyze selected Claude Code or Codex history after separate consent
 - `/prompt-sensei report` — run the report script and display session statistics
 - `/prompt-sensei clear` — run the clear script to delete session data
 - `/prompt-sensei update` — run the update script to pull the latest version and rebuild
 
 If the user asks for `/prompt-sensei review`, `/prompt-sensei score`, "review my prompt", or "score this prompt", redirect briefly: `Use /prompt-sensei improve <prompt>.`
 
-In Codex or other environments without slash-command support, treat natural-language requests such as "use prompt-sensei", "improve this prompt", or "show my prompt-sensei report" as equivalent invocations.
+In Codex or other environments without slash-command support, treat natural-language requests such as "use prompt-sensei", "improve this prompt", "look back at my prompt history", or "show my prompt-sensei report" as equivalent invocations.
 
 When running bundled scripts, use the installed skill root:
 - Claude Code default: `~/.claude/skills/prompt-sensei`
 - Codex default: `~/.codex/skills/prompt-sensei`
+- IDE/plugin environments that load Claude Code or Codex skills should use the same installed skill root as that host tool.
 - In Claude Code, always call scripts by absolute path. Do not `cd` into the skill directory before running a script; Claude Code may reset the shell cwd and show a misleading warning.
 
 ---
@@ -328,6 +330,75 @@ If the event file exists but only has session-start events in the selected repor
 
 ---
 
+## Behavior in Lookback Mode
+
+Lookback analyzes selected local Claude Code or Codex history. It is separate from observe consent because it may read raw historical user prompts before redaction.
+
+When the user types `/prompt-sensei lookback`:
+
+1. Discover local sessions first:
+
+```bash
+node ~/.claude/skills/prompt-sensei/dist/scripts/lookback.js --discover
+```
+
+Use the installed skill root for the current environment, e.g. `~/.codex/skills/prompt-sensei` in Codex.
+
+2. Ask the user to choose one source:
+   - select one discovered session
+   - auto select all sessions
+   - manual path/source (ask whether it is Claude Code or Codex if the path does not make that obvious)
+
+3. Ask for analysis format:
+   - `one-by-one` — concise coaching for selected prompts
+   - `report` — a longer lookback report with repeated patterns and 1-5 tips
+
+4. Ask how many recent user prompts to analyze:
+   - default: `30`
+   - accept a number or `all`
+   - if the number is greater than `50` or the user chooses `all`, ask for confirmation before extraction
+   - hard cap: `500`
+
+5. Show this consent text before reading history:
+
+```
+Prompt Sensei will read selected local conversation history and redact user prompts before analysis.
+Redacted user prompts may be shown to the current AI agent for coaching.
+Raw history will not be copied into Prompt Sensei storage.
+Raw prompt text will not be saved.
+
+Continue? (yes / no)
+```
+
+If the user does not consent, stop.
+
+6. Extract the selected history:
+   - one discovered session: `node ~/.claude/skills/prompt-sensei/dist/scripts/lookback.js --extract --path <session-jsonl-path> --mode <report|one-by-one> --limit <number|all>`
+   - all sessions: `node ~/.claude/skills/prompt-sensei/dist/scripts/lookback.js --extract --source all --session all --mode <report|one-by-one> --limit <number|all>`
+   - manual path: `node ~/.claude/skills/prompt-sensei/dist/scripts/lookback.js --extract --source <claude|codex> --path <file-or-dir> --mode <report|one-by-one> --limit <number|all>`
+
+7. Analyze only user prompts. Do not analyze assistant responses.
+
+8. Avoid direct quotes from the prompts by default. Give direct advice such as "your prompt did not mention which test failed" rather than quoting the prompt text.
+
+9. For `one-by-one`, provide concise feedback per prompt. For `report`, include:
+   - repeated prompting patterns
+   - strongest prompt habits
+   - 1-5 next habits depending on history length
+   - a short practice recommendation
+
+10. Ask whether to save the generated markdown report. Save only after explicit confirmation:
+
+```bash
+node ~/.claude/skills/prompt-sensei/dist/scripts/lookback.js --save-report --title "Prompt Sensei Lookback"
+```
+
+Pass the report content on stdin. Saved reports go to `~/.prompt-sensei/reports/`.
+
+Lookback does not store raw history, prompt hashes, or derived metadata by default.
+
+---
+
 ## Behavior in Clear Mode
 
 Run the clear script:
@@ -351,9 +422,10 @@ Commands:
   /prompt-sensei observe               Score prompts as you write them
   /prompt-sensei stop                  Stop scoring for this session
   /prompt-sensei improve "<prompt>"    Rewrite a prompt with one teaching note
+  /prompt-sensei lookback              Analyze selected local prompt history
   /prompt-sensei report                Show your session statistics
   /prompt-sensei update                Pull the latest version and rebuild
-  /prompt-sensei clear                 Delete local session data
+  /prompt-sensei clear                 Delete local Prompt Sensei data
   /prompt-sensei help                  Show this help
 
 Prompt stages:   Exploration · Diagnosis · Execution · Verification · Reusable workflow · Action

--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -62,6 +62,8 @@ Prompt Sensei tracks trends, not one-off scores. A prompt that scores 50/100 is 
 
 The reports are designed to show movement, not rank. They separate scored observations from hash-only hook captures, and the most useful signal is the next habit to practice for the task type the user actually does. The goal is "Is the user learning?" not "Is this prompt good?"
 
+Lookback extends this idea to past sessions. It is not a surveillance feature or a transcript archive. It is a consent-based reflection tool: read selected local history, avoid storing raw prompts, identify repeated habits, and turn that history into a few concrete things to practice next.
+
 ---
 
 ## Privacy as a first principle

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -38,6 +38,14 @@ Prompt Sensei also stores cached update-check status when update checks run:
 | `currentSha` | string | `"65fb4ad..."` |
 | `remoteSha` | string | `"31e4a5b..."` |
 
+When you explicitly choose to save a lookback report, Prompt Sensei stores the generated markdown report:
+
+| Field | Type | Example |
+|---|---|---|
+| Report file | Markdown | `~/.prompt-sensei/reports/2026-04-26T...-lookback.md` |
+
+Saved lookback reports are optional and are created only after confirmation.
+
 ---
 
 ## What is never stored
@@ -47,6 +55,9 @@ Prompt Sensei also stores cached update-check status when update checks run:
 - Code snippets from your prompts
 - File contents
 - Usernames, emails, or project identifiers
+- Raw lookback history
+- Lookback prompt hashes
+- Derived lookback metadata, unless you save a markdown report yourself
 
 ---
 
@@ -57,7 +68,9 @@ All data is written to `~/.prompt-sensei/events.jsonl` — a single newline-deli
 ```
 ~/.prompt-sensei/
 ├── events.jsonl    ← one JSON record per observed prompt
-└── config.json     ← consent status and preferences
+├── config.json     ← consent status and preferences
+├── update-check.json
+└── reports/        ← optional saved lookback reports
 ```
 
 This directory is **not** inside your project repo. It is in your home directory and will not be committed to version control.
@@ -69,6 +82,25 @@ This directory is **not** inside your project repo. It is in your home directory
 The first time you run `/prompt-sensei observe`, Prompt Sensei will show you exactly what it intends to store and ask for confirmation before writing anything. It will not activate observation mode without your explicit consent.
 
 Consent is stored in `~/.prompt-sensei/config.json`. The prompt only appears once.
+
+Lookback uses separate consent because it reads selected local conversation history before redaction. Observe consent does not automatically grant lookback permission.
+
+---
+
+## Lookback privacy
+
+When you run `/prompt-sensei lookback`, Prompt Sensei first discovers local Claude Code and Codex session files using metadata such as file paths, session IDs, titles when available, and file timestamps. It does not parse conversation files or extract prompt text during discovery. Before extracting prompts, it asks for explicit consent with the following guarantees:
+
+- Selected local history is read locally
+- User prompts are redacted before analysis
+- Redacted prompts may be shown to the current AI agent for coaching
+- Assistant responses are not analyzed
+- Raw history is not copied into `~/.prompt-sensei`
+- Raw prompt text, prompt hashes, and derived lookback metadata are not stored by default
+
+Lookback can optionally save the generated markdown report to `~/.prompt-sensei/reports/`, but only after you confirm. The report is written by Prompt Sensei on your machine and can be deleted at any time.
+
+Lookback does not make network calls itself. The active AI coding tool may process the redacted prompts according to that tool's normal model behavior.
 
 ---
 
@@ -117,6 +149,8 @@ rm -rf ~/.prompt-sensei/
 ```
 
 There is no account to close, no server to notify, and no backup to remove. Deleting the directory is a complete wipe.
+
+`/prompt-sensei clear` also deletes saved lookback reports under `~/.prompt-sensei/reports/`.
 
 To also reset consent (so the skill asks again on next use):
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prompt-sensei",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prompt-sensei",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "commonjs",
   "scripts": {
     "build": "tsc",
+    "init": "node dist/scripts/observe.js --init",
     "observe": "node dist/scripts/observe.js",
     "report": "node dist/scripts/report.js",
     "lookback": "node dist/scripts/lookback.js",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "name": "prompt-sensei",
-  "version": "0.2.0",
-  "description": "A quiet, local-first prompt mentor for engineers using AI coding tools",
+  "version": "0.3.0",
+  "description": "A quiet, local-first prompt mentor with improve, observe, report, and lookback workflows",
   "type": "commonjs",
   "scripts": {
     "build": "tsc",
     "observe": "node dist/scripts/observe.js",
     "report": "node dist/scripts/report.js",
+    "lookback": "node dist/scripts/lookback.js",
     "check-update": "node dist/scripts/update.js --check",
     "update": "node dist/scripts/update.js --apply",
     "clear-data": "node dist/scripts/clear.js"
@@ -25,6 +26,8 @@
     "ai-coding",
     "developer-tools",
     "prompt-coach",
+    "prompt-history",
+    "lookback",
     "local-first",
     "engineering-productivity",
     "ai-agents"

--- a/scripts/clear.ts
+++ b/scripts/clear.ts
@@ -1,13 +1,13 @@
 #!/usr/bin/env node
 /**
- * Delete local session data.
+ * Delete local Prompt Sensei data.
  * Usage: clear.js [--force] [--all]
  *
  * --force   Skip confirmation prompt
  * --all     Also delete config.json (resets consent)
  */
 
-import { existsSync, unlinkSync, readFileSync } from "fs";
+import { existsSync, unlinkSync, readFileSync, rmSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
 import * as readline from "readline";
@@ -16,6 +16,7 @@ const DATA_DIR = join(homedir(), ".prompt-sensei");
 const EVENTS_FILE = join(DATA_DIR, "events.jsonl");
 const CONFIG_FILE = join(DATA_DIR, "config.json");
 const UPDATE_FILE = join(DATA_DIR, "update-check.json");
+const REPORTS_DIR = join(DATA_DIR, "reports");
 
 function countEntries(): number {
   if (!existsSync(EVENTS_FILE)) return 0;
@@ -37,6 +38,12 @@ function deleteData(all: boolean): void {
     unlinkSync(UPDATE_FILE);
     deleted++;
     console.log(`Deleted: ${UPDATE_FILE}`);
+  }
+
+  if (existsSync(REPORTS_DIR)) {
+    rmSync(REPORTS_DIR, { recursive: true, force: true });
+    deleted++;
+    console.log(`Deleted: ${REPORTS_DIR}`);
   }
 
   if (all && existsSync(CONFIG_FILE)) {
@@ -69,7 +76,12 @@ async function main(): Promise<void> {
 
   const entries = countEntries();
 
-  if (entries === 0 && !existsSync(CONFIG_FILE)) {
+  if (
+    entries === 0 &&
+    !existsSync(CONFIG_FILE) &&
+    !existsSync(UPDATE_FILE) &&
+    !existsSync(REPORTS_DIR)
+  ) {
     console.log("Nothing to clear — no session data found.");
     return;
   }
@@ -79,7 +91,9 @@ async function main(): Promise<void> {
     return;
   }
 
-  const what = all ? "events and config (resets consent)" : "events";
+  const what = all
+    ? "events, update cache, saved reports, and config (resets consent)"
+    : "events, update cache, and saved reports";
   const ok = await confirm(
     `Delete ${entries} prompt entries (${what})? [y/N] `
   );

--- a/scripts/lookback.ts
+++ b/scripts/lookback.ts
@@ -64,6 +64,11 @@ interface SessionSummary {
   lastTs?: string;
 }
 
+interface PromptSelection {
+  selected: PromptRecord[];
+  skippedLowSignal: number;
+}
+
 function parseArgs(argv: string[]): Args {
   const result: Args = {};
   for (let i = 2; i < argv.length; i++) {
@@ -172,6 +177,26 @@ function isLikelyUserPrompt(text: string): boolean {
   if (trimmed.startsWith("<user_editable_context>")) return false;
   if (trimmed.startsWith("<local-command-")) return false;
   return true;
+}
+
+function isLowSignalPrompt(text: string): boolean {
+  const trimmed = text.trim();
+  const lower = trimmed.toLowerCase();
+
+  if (!trimmed) return true;
+  if (/<command-name>[\s\S]*<\/command-name>/i.test(trimmed)) return true;
+  if (/<command-message>[\s\S]*<\/command-message>/i.test(trimmed)) return true;
+  if (/^\/prompt-sensei\b/i.test(trimmed)) return true;
+  if (/^just reply\b/i.test(trimmed)) return true;
+  if (/^reply (with )?["']?(ok|yes|no)["']?/i.test(trimmed)) return true;
+  if (/^let'?s do\b/i.test(trimmed) && /\b(one-by-one|report|all|manual|[0-9]+)\b/i.test(trimmed)) return true;
+  if (/^(y|yes|n|no|ok|okay|sure|continue|go ahead|proceed|confirm)$/i.test(trimmed)) return true;
+  if (/^(all|manual|one-by-one|report)$/i.test(trimmed)) return true;
+  if (/^[0-9]+$/.test(trimmed)) return true;
+  if (/^[aam]$/i.test(trimmed)) return true;
+  if (trimmed.startsWith("This session is being continued from a previous conversation that ran out of context.")) return true;
+  if (trimmed.startsWith("Summary:") && lower.includes("primary request and intent")) return true;
+  return false;
 }
 
 function normalizeTimestamp(value: unknown, fallbackPath: string): string {
@@ -389,15 +414,23 @@ function truncate(text: string, maxChars: number): string {
   return `${text.slice(0, maxChars).trimEnd()}\n[TRUNCATED]`;
 }
 
-function selectRecentPrompts(prompts: PromptRecord[], limit: number): PromptRecord[] {
-  return [...prompts]
+function selectRecentPrompts(prompts: PromptRecord[], limit: number): PromptSelection {
+  const candidates = [...prompts]
     .sort((a, b) => new Date(b.ts).getTime() - new Date(a.ts).getTime())
-    .slice(0, limit)
+    .slice(0, limit);
+  const selected = candidates
+    .filter((prompt) => !isLowSignalPrompt(prompt.text))
     .sort((a, b) => new Date(a.ts).getTime() - new Date(b.ts).getTime());
+
+  return {
+    selected,
+    skippedLowSignal: candidates.length - selected.length,
+  };
 }
 
 function printAnalysisPack(prompts: PromptRecord[], mode: Mode, requestedLimit: string | undefined, maxChars: number): void {
-  const selected = selectRecentPrompts(prompts, parseLimit(requestedLimit));
+  const selection = selectRecentPrompts(prompts, parseLimit(requestedLimit));
+  const { selected, skippedLowSignal } = selection;
   const total = prompts.length;
   const limitLabel = requestedLimit ?? String(DEFAULT_PROMPT_LIMIT);
   const capped = requestedLimit === "all" && total > MAX_PROMPT_LIMIT;
@@ -406,6 +439,10 @@ function printAnalysisPack(prompts: PromptRecord[], mode: Mode, requestedLimit: 
   console.log(`Mode: ${mode}`);
   console.log(`Selected prompts: ${selected.length} of ${total}`);
   console.log(`Selection: most recent ${limitLabel}, shown oldest to newest`);
+  if (skippedLowSignal > 0) {
+    console.log(`Skipped low-signal prompts: ${skippedLowSignal}`);
+    console.log("[Sensei: skipped grading for low-signal prompt]");
+  }
   if (capped) {
     console.log(`Limit note: "all" was capped at ${MAX_PROMPT_LIMIT} prompts.`);
   }

--- a/scripts/lookback.ts
+++ b/scripts/lookback.ts
@@ -1,0 +1,526 @@
+#!/usr/bin/env node
+/**
+ * Discover and extract local conversation history for Prompt Sensei lookback.
+ *
+ * Usage:
+ *   lookback.js --discover [--source claude|codex|all]
+ *   lookback.js --extract [--source claude|codex] --path <file-or-dir> [--mode report|one-by-one] [--limit 30|all]
+ *   lookback.js --extract --source claude|codex|all --session all [--mode report|one-by-one] [--limit 30|all]
+ *   lookback.js --save-report [--title "Prompt Sensei Lookback"] < report.md
+ *
+ * The extract path prints redacted user prompts to stdout for the active agent
+ * to analyze. It never writes raw history or derived metadata to Prompt Sensei
+ * storage.
+ */
+
+import { createHash } from "crypto";
+import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from "fs";
+import { homedir } from "os";
+import { basename, dirname, join, resolve } from "path";
+import * as readline from "readline";
+
+const DATA_DIR = join(homedir(), ".prompt-sensei");
+const REPORTS_DIR = join(DATA_DIR, "reports");
+const CLAUDE_PROJECTS_DIR = join(homedir(), ".claude", "projects");
+const CODEX_SESSIONS_DIR = join(homedir(), ".codex", "sessions");
+const CODEX_SESSION_INDEX = join(homedir(), ".codex", "session_index.jsonl");
+const DEFAULT_PROMPT_LIMIT = 30;
+const CONFIRM_PROMPT_THRESHOLD = 50;
+const MAX_PROMPT_LIMIT = 500;
+const DEFAULT_DISCOVERY_LIMIT = 20;
+const DEFAULT_PROMPT_CHAR_LIMIT = 1200;
+
+const REDACT_PATTERNS: Array<[RegExp, string]> = [
+  [/\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g, "[EMAIL]"],
+  [/\b(sk-|sk-ant-|ghp_|github_pat_|xox[baprs]-)[A-Za-z0-9\-_]{10,}/g, "[API_KEY]"],
+  [/\b(password|passwd|secret|token|api_?key)\s*[:=]\s*\S+/gi, "[CREDENTIAL]"],
+  [/-----BEGIN [A-Z ]+-----[\s\S]+?-----END [A-Z ]+-----/g, "[PRIVATE_KEY]"],
+  [/https?:\/\/[^\s]+\?[^\s]+/g, "[URL_WITH_PARAMS]"],
+];
+
+type Source = "claude" | "codex";
+type Mode = "report" | "one-by-one";
+
+interface Args {
+  [key: string]: string | boolean | undefined;
+}
+
+interface PromptRecord {
+  source: Source;
+  sessionId: string;
+  path: string;
+  ts: string;
+  text: string;
+  index: number;
+}
+
+interface SessionSummary {
+  source: Source;
+  sessionId: string;
+  title?: string;
+  path: string;
+  promptCount?: number;
+  firstTs?: string;
+  lastTs?: string;
+}
+
+function parseArgs(argv: string[]): Args {
+  const result: Args = {};
+  for (let i = 2; i < argv.length; i++) {
+    const arg = argv[i];
+    if (!arg.startsWith("--")) continue;
+    const eq = arg.indexOf("=");
+    if (eq !== -1) {
+      result[arg.slice(2, eq)] = arg.slice(eq + 1);
+      continue;
+    }
+
+    const key = arg.slice(2);
+    const next = argv[i + 1];
+    if (next !== undefined && !next.startsWith("--")) {
+      result[key] = next;
+      i++;
+    } else {
+      result[key] = true;
+    }
+  }
+  return result;
+}
+
+function asString(value: string | boolean | undefined): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function readJsonLines(path: string): unknown[] {
+  if (!existsSync(path)) return [];
+  return readFileSync(path, "utf8")
+    .split("\n")
+    .filter((line) => line.trim())
+    .flatMap((line) => {
+      try {
+        return [JSON.parse(line) as unknown];
+      } catch {
+        return [];
+      }
+    });
+}
+
+function walkJsonlFiles(root: string): string[] {
+  if (!existsSync(root)) return [];
+  const results: string[] = [];
+
+  function visit(path: string): void {
+    let stats;
+    try {
+      stats = statSync(path);
+    } catch {
+      return;
+    }
+
+    if (stats.isDirectory()) {
+      for (const entry of readdirSync(path)) {
+        visit(join(path, entry));
+      }
+      return;
+    }
+
+    if (stats.isFile() && path.endsWith(".jsonl")) {
+      results.push(path);
+    }
+  }
+
+  visit(root);
+  return results.sort();
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function getString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function contentToText(content: unknown): string {
+  if (typeof content === "string") return content;
+
+  if (Array.isArray(content)) {
+    return content
+      .map((block) => {
+        if (typeof block === "string") return block;
+        if (!isRecord(block)) return "";
+        const type = getString(block["type"]);
+        if (type === "tool_result" || type === "image" || type === "input_image") return "";
+        return getString(block["text"]) ?? getString(block["content"]) ?? "";
+      })
+      .filter(Boolean)
+      .join("\n");
+  }
+
+  if (isRecord(content)) {
+    return getString(content["text"]) ?? getString(content["content"]) ?? "";
+  }
+
+  return "";
+}
+
+function isLikelyUserPrompt(text: string): boolean {
+  const trimmed = text.trim();
+  if (!trimmed) return false;
+  if (trimmed.startsWith("<environment_context>")) return false;
+  if (trimmed.startsWith("<turn_aborted>")) return false;
+  if (trimmed.startsWith("<user_editable_context>")) return false;
+  if (trimmed.startsWith("<local-command-")) return false;
+  return true;
+}
+
+function normalizeTimestamp(value: unknown, fallbackPath: string): string {
+  const ts = getString(value);
+  if (ts && Number.isFinite(new Date(ts).getTime())) return ts;
+
+  try {
+    return statSync(fallbackPath).mtime.toISOString();
+  } catch {
+    return new Date(0).toISOString();
+  }
+}
+
+function sessionIdFromPath(path: string): string {
+  return basename(path).replace(/\.jsonl$/, "");
+}
+
+function codexSessionIdFromPath(path: string): string {
+  const name = sessionIdFromPath(path);
+  const match = name.match(/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/i);
+  return match?.[1] ?? name.replace(/^rollout-/, "");
+}
+
+function parseClaudePrompts(path: string): PromptRecord[] {
+  const lines = readJsonLines(path);
+  const prompts: PromptRecord[] = [];
+  for (const line of lines) {
+    if (!isRecord(line)) continue;
+    const message = line["message"];
+    if (!isRecord(message)) continue;
+    if (message["role"] !== "user") continue;
+    if (line["isMeta"] === true) continue;
+
+    const text = contentToText(message["content"]);
+    if (!isLikelyUserPrompt(text)) continue;
+
+    prompts.push({
+      source: "claude",
+      sessionId: getString(line["sessionId"]) ?? sessionIdFromPath(path),
+      path,
+      ts: normalizeTimestamp(line["timestamp"], path),
+      text,
+      index: prompts.length + 1,
+    });
+  }
+  return prompts;
+}
+
+function parseCodexPrompts(path: string): PromptRecord[] {
+  const lines = readJsonLines(path);
+  const sessionId = codexSessionIdFromFile(path, lines);
+  const prompts: PromptRecord[] = [];
+  for (const line of lines) {
+    if (!isRecord(line) || line["type"] !== "response_item") continue;
+    const payload = line["payload"];
+    if (!isRecord(payload) || payload["role"] !== "user") continue;
+    const text = contentToText(payload["content"]);
+    if (!isLikelyUserPrompt(text)) continue;
+
+    prompts.push({
+      source: "codex",
+      sessionId,
+      path,
+      ts: normalizeTimestamp(line["timestamp"], path),
+      text,
+      index: prompts.length + 1,
+    });
+  }
+  return prompts;
+}
+
+function codexSessionIdFromFile(path: string, lines: unknown[]): string {
+  const meta = lines.find((line) => isRecord(line) && line["type"] === "session_meta");
+  if (isRecord(meta)) {
+    const payload = meta["payload"];
+    if (isRecord(payload)) {
+      const id = getString(payload["id"]);
+      if (id) return id;
+    }
+  }
+  return codexSessionIdFromPath(path);
+}
+
+function parsePrompts(path: string, sourceHint?: Source): PromptRecord[] {
+  const source = sourceHint ?? detectSource(path);
+  if (source === "claude") return parseClaudePrompts(path);
+  return parseCodexPrompts(path);
+}
+
+function detectSource(path: string): Source {
+  const normalized = path.replaceAll("\\", "/");
+  if (normalized.includes("/.codex/")) return "codex";
+  return "claude";
+}
+
+function summarizeSession(path: string, source: Source, titleMap: Map<string, string>): SessionSummary | null {
+  let stats;
+  try {
+    stats = statSync(path);
+  } catch {
+    return null;
+  }
+
+  const sessionId = source === "codex" ? codexSessionIdFromPath(path) : sessionIdFromPath(path);
+  return {
+    source,
+    sessionId,
+    title: titleMap.get(sessionId),
+    path,
+    lastTs: stats.mtime.toISOString(),
+  };
+}
+
+function loadCodexTitleMap(): Map<string, string> {
+  const titles = new Map<string, string>();
+  if (!existsSync(CODEX_SESSION_INDEX)) return titles;
+
+  for (const line of readJsonLines(CODEX_SESSION_INDEX)) {
+    if (!isRecord(line)) continue;
+    const id = getString(line["id"]);
+    const title = getString(line["thread_name"]);
+    if (id && title) titles.set(id, title);
+  }
+  return titles;
+}
+
+function sourceRoots(source: string): Array<{ source: Source; root: string }> {
+  if (source === "claude") return [{ source: "claude", root: CLAUDE_PROJECTS_DIR }];
+  if (source === "codex") return [{ source: "codex", root: CODEX_SESSIONS_DIR }];
+  return [
+    { source: "claude", root: CLAUDE_PROJECTS_DIR },
+    { source: "codex", root: CODEX_SESSIONS_DIR },
+  ];
+}
+
+function discoverSessions(sourceArg: string, maxSessions: number): SessionSummary[] {
+  const titleMap = loadCodexTitleMap();
+  const sessions = sourceRoots(sourceArg)
+    .flatMap(({ source, root }) =>
+      walkJsonlFiles(root)
+        .filter((path) => !path.includes("/subagents/"))
+        .map((path) => summarizeSession(path, source, titleMap))
+        .filter((session): session is SessionSummary => session !== null)
+    )
+    .sort((a, b) => new Date(b.lastTs ?? 0).getTime() - new Date(a.lastTs ?? 0).getTime());
+
+  return sessions.slice(0, maxSessions);
+}
+
+function printDiscovery(sessions: SessionSummary[]): void {
+  console.log("# Prompt Sensei Lookback Sessions");
+  if (sessions.length === 0) {
+    console.log("No Claude Code or Codex sessions found.");
+    return;
+  }
+
+  console.log("Select one session by path, or choose all sessions in the guided flow.\n");
+  sessions.forEach((session, index) => {
+    const title = session.title ? ` — ${session.title}` : "";
+    const count = session.promptCount === undefined ? "prompt count available after consent" : `${session.promptCount} prompts`;
+    console.log(`${index + 1}. ${session.source} · ${count} · latest ${session.lastTs ?? "unknown"}${title}`);
+    console.log(`   session: ${session.sessionId}`);
+    console.log(`   path: ${session.path}`);
+  });
+}
+
+function parseLimit(value: string | undefined): number {
+  if (!value) return DEFAULT_PROMPT_LIMIT;
+  if (value === "all") return MAX_PROMPT_LIMIT;
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_PROMPT_LIMIT;
+  return Math.min(parsed, MAX_PROMPT_LIMIT);
+}
+
+function collectPrompts(args: Args): PromptRecord[] {
+  const pathArg = asString(args["path"]);
+  const sourceArg = asString(args["source"]) ?? "all";
+  const sessionArg = asString(args["session"]);
+
+  if (pathArg) {
+    const resolved = resolve(pathArg.replace(/^~(?=$|\/)/, homedir()));
+    if (!existsSync(resolved)) {
+      process.stderr.write(`Path not found: ${resolved}\n`);
+      process.exit(1);
+    }
+
+    const stats = statSync(resolved);
+    const paths = stats.isDirectory() ? walkJsonlFiles(resolved) : [resolved];
+    const sourceHint = sourceArg === "claude" || sourceArg === "codex" ? sourceArg : undefined;
+    return paths.flatMap((path) => parsePrompts(path, sourceHint));
+  }
+
+  if (sessionArg === "all") {
+    return sourceRoots(sourceArg).flatMap(({ source, root }) =>
+      walkJsonlFiles(root)
+        .filter((path) => !path.includes("/subagents/"))
+        .flatMap((path) => parsePrompts(path, source))
+    );
+  }
+
+  process.stderr.write("Provide --path <file-or-dir> or --session all with --source claude|codex|all.\n");
+  process.exit(1);
+}
+
+function redact(text: string): string {
+  let result = text.replaceAll(homedir(), "~");
+  for (const [pattern, replacement] of REDACT_PATTERNS) {
+    result = result.replace(pattern, replacement);
+  }
+  return result;
+}
+
+function truncate(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  return `${text.slice(0, maxChars).trimEnd()}\n[TRUNCATED]`;
+}
+
+function selectRecentPrompts(prompts: PromptRecord[], limit: number): PromptRecord[] {
+  return [...prompts]
+    .sort((a, b) => new Date(b.ts).getTime() - new Date(a.ts).getTime())
+    .slice(0, limit)
+    .sort((a, b) => new Date(a.ts).getTime() - new Date(b.ts).getTime());
+}
+
+function printAnalysisPack(prompts: PromptRecord[], mode: Mode, requestedLimit: string | undefined, maxChars: number): void {
+  const selected = selectRecentPrompts(prompts, parseLimit(requestedLimit));
+  const total = prompts.length;
+  const limitLabel = requestedLimit ?? String(DEFAULT_PROMPT_LIMIT);
+  const capped = requestedLimit === "all" && total > MAX_PROMPT_LIMIT;
+
+  console.log("# Prompt Sensei Lookback Analysis Pack");
+  console.log(`Mode: ${mode}`);
+  console.log(`Selected prompts: ${selected.length} of ${total}`);
+  console.log(`Selection: most recent ${limitLabel}, shown oldest to newest`);
+  if (capped) {
+    console.log(`Limit note: "all" was capped at ${MAX_PROMPT_LIMIT} prompts.`);
+  }
+  if (selected.length > CONFIRM_PROMPT_THRESHOLD) {
+    console.log(`Large-run note: this pack has more than ${CONFIRM_PROMPT_THRESHOLD} prompts; the guided flow should confirm this before analysis.`);
+  }
+  console.log("");
+  console.log("Privacy: prompts below are redacted and printed for the active agent to analyze. Prompt Sensei does not save raw history or derived lookback metadata.");
+  console.log("Instruction: avoid direct quotes in the final answer unless the user explicitly asks for examples.");
+
+  if (mode === "one-by-one") {
+    console.log("Analysis target: give concise coaching for each prompt, with one habit per prompt.");
+  } else {
+    console.log("Analysis target: produce a lookback report with repeated patterns, strong habits, and 1-5 next tips.");
+  }
+
+  console.log("\n## Redacted User Prompts");
+  selected.forEach((prompt, index) => {
+    const redacted = truncate(redact(prompt.text), maxChars);
+    console.log(`\n### ${index + 1}. ${prompt.ts}`);
+    console.log(`Session: ${prompt.sessionId}`);
+    console.log(`Prompt index in session: ${prompt.index}`);
+    console.log("```txt");
+    console.log(redacted);
+    console.log("```");
+  });
+}
+
+async function readStdin(): Promise<string> {
+  if (process.stdin.isTTY) return "";
+  const rl = readline.createInterface({ input: process.stdin });
+  const lines: string[] = [];
+  for await (const line of rl) {
+    lines.push(line);
+  }
+  return lines.join("\n");
+}
+
+function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 48) || "lookback";
+}
+
+async function saveReport(args: Args): Promise<void> {
+  const body = await readStdin();
+  if (!body.trim()) {
+    process.stderr.write("No report content received on stdin.\n");
+    process.exit(1);
+  }
+
+  const title = asString(args["title"]) ?? "Prompt Sensei Lookback";
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const file = join(REPORTS_DIR, `${stamp}-${slugify(title)}.md`);
+  if (!existsSync(REPORTS_DIR)) {
+    mkdirSync(REPORTS_DIR, { recursive: true });
+  }
+
+  writeFileSync(file, `${body.trim()}\n`, "utf8");
+  console.log(`Saved lookback report: ${file}`);
+}
+
+function printHelp(): void {
+  console.log(`Prompt Sensei Lookback
+
+Commands:
+  --discover [--source claude|codex|all]
+  --extract [--source claude|codex] --path <file-or-dir> [--mode report|one-by-one] [--limit 30|all]
+  --extract --source claude|codex|all --session all [--mode report|one-by-one] [--limit 30|all]
+  --save-report [--title "Prompt Sensei Lookback"] < report.md
+
+Defaults:
+  mode: report
+  limit: ${DEFAULT_PROMPT_LIMIT}
+  max prompts: ${MAX_PROMPT_LIMIT}
+  max chars per prompt: ${DEFAULT_PROMPT_CHAR_LIMIT}
+
+Privacy:
+  Raw history is read locally, redacted, and printed to stdout for the active
+  agent to analyze. Prompt Sensei does not store raw history or lookback
+  metadata by default.`);
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv);
+  if (args["help"]) {
+    printHelp();
+    return;
+  }
+
+  if (args["save-report"]) {
+    await saveReport(args);
+    return;
+  }
+
+  if (args["extract"]) {
+    const mode = (asString(args["mode"]) ?? "report") as Mode;
+    if (mode !== "report" && mode !== "one-by-one") {
+      process.stderr.write("Invalid --mode. Use report or one-by-one.\n");
+      process.exit(1);
+    }
+    const maxChars = Number.parseInt(asString(args["max-chars-per-prompt"]) ?? "", 10) || DEFAULT_PROMPT_CHAR_LIMIT;
+    const prompts = collectPrompts(args);
+    printAnalysisPack(prompts, mode, asString(args["limit"]), maxChars);
+    return;
+  }
+
+  const source = asString(args["source"]) ?? "all";
+  const maxSessions = Number.parseInt(asString(args["max-sessions"]) ?? "", 10) || DEFAULT_DISCOVERY_LIMIT;
+  printDiscovery(discoverSessions(source, maxSessions));
+}
+
+main().catch((err) => {
+  process.stderr.write(`lookback error: ${err instanceof Error ? err.message : String(err)}\n`);
+  process.exit(1);
+});

--- a/scripts/observe.ts
+++ b/scripts/observe.ts
@@ -72,6 +72,24 @@ function parseArgs(argv: string[]): Record<string, string | boolean> {
   return result;
 }
 
+function printInteractiveHelp(): void {
+  console.log(`Prompt Sensei Observe
+
+This command records local observation metadata. It does not start live coaching by itself.
+
+Use one of:
+  npm run init
+  node dist/scripts/observe.js --init
+  node dist/scripts/observe.js --stage execution --score 4 --task-type debugging
+
+In Claude Code, start live coaching with:
+  /prompt-sensei observe
+
+In Codex or other hosts without slash commands, ask the agent:
+  Use prompt-sensei observe mode.
+`);
+}
+
 interface Config {
   v: number;
   consentGiven: boolean;
@@ -136,6 +154,11 @@ async function readStdin(): Promise<string> {
 
 async function main(): Promise<void> {
   const args = parseArgs(process.argv);
+
+  if (process.argv.length <= 2 && process.stdin.isTTY) {
+    printInteractiveHelp();
+    return;
+  }
 
   if (args["init"] === true) {
     const config = loadConfig();


### PR DESCRIPTION
## Summary
- Release Prompt Sensei v0.3.0 from `develop` to `main`.
- Adds guided lookback for Claude Code and Codex history with separate consent, visible session selection, redaction, and optional saved reports.
- Improves observe setup for Codex/non-slash-command environments with `npm run init` and clearer interactive `npm run observe` behavior.
- Filters low-signal command/control prompts from lookback analysis and documents skipped grading behavior.

## Validation
- `npm run build`
- `git diff --check`
- `node dist/scripts/lookback.js --help`
- `npm run observe`
- Fresh Codex install smoke test from GitHub, then `develop` checkout for v0.3.0 behavior